### PR TITLE
fix(runtime): support binary purge on Windows

### DIFF
--- a/apps/runtime/src/commands/purge.ts
+++ b/apps/runtime/src/commands/purge.ts
@@ -4,10 +4,8 @@
 // `caracal purge`: centralized cleanup for selectable targets across dev and runtime installs.
 
 import { existsSync, readdirSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { spawnSync } from 'node:child_process'
 import { createInterface } from 'node:readline'
-import { join, relative } from 'node:path'
+import { basename, dirname, join, relative, resolve, win32 } from 'node:path'
 import pg from 'pg'
 import { devSecretsHome } from '@caracalai/server-core'
 import { authMaintenanceUrl, configuredAuthDatabaseName } from './authStore.ts'
@@ -15,6 +13,7 @@ import { defaultCaracalConfigDir } from '@caracalai/engine/runtime-config'
 import {
   caracalBinaries as caracalBinariesCore,
   composeRun,
+  defaultCaracalInstallDir,
   installRuntimeAssets,
   listCaracalImages,
   removeFsPath,
@@ -25,6 +24,14 @@ import { runtimePaths } from '@caracalai/engine'
 import { composeUnavailableReason, dockerComposeAvailable, resolvePaths } from './stack.ts'
 import { showHelp } from './shared.ts'
 import { style, SYMBOL, printError, printWarn, printStep, printSuccess, printHeader } from '../style.ts'
+import {
+  deferRunningExecutableRemoval,
+  isRunningExecutable,
+  isWindowsRuntime,
+  removeWindowsUserPathEntry,
+  resolvePnpm,
+  spawnSyncTree,
+} from '../processTree.ts'
 
 type TargetId = 'stack' | 'volumes' | 'logs' | 'config' | 'runtime' | 'secrets' | 'web' | 'cache' | 'images' | 'binary'
 
@@ -78,6 +85,7 @@ interface PurgeContext {
   repoRoot: string | undefined
   composeAvailable: boolean
   dryRun: boolean
+  binaryDiscovery?: { installDir: string; paths: string[] }
 }
 
 interface SecretCleanupTarget {
@@ -162,7 +170,7 @@ function purgeHelp(): never {
     '',
     'Cached images & binaries (artifacts):',
     '  images      Remove cached Caracal docker images (caracal/*, ghcr.io/garudex-labs/caracal-*)',
-    '  binary      Uninstall Caracal runtime and web console binaries from $CARACAL_INSTALL_DIR (default ~/.local/bin)',
+    '  binary      Uninstall the Caracal runtime binary from $CARACAL_INSTALL_DIR (platform default when unset)',
     '',
     'Aggregate:',
     '  all         Purge every applicable target (destructive: wipes volumes, runtime, config, web, images, binary)',
@@ -272,15 +280,31 @@ function removePath(path: string, ctx: PurgeContext, label: string): void {
   process.stdout.write(`  ${style.success(SYMBOL.ok)} removed ${style.code(label)}: ${path}\n`)
 }
 
-function caracalBinariesPaths(): string[] {
-  const installDir = process.env.CARACAL_INSTALL_DIR ?? join(homedir(), '.local', 'bin')
+function discoverCaracalBinaries(): { installDir: string; paths: string[] } {
+  const installDir = process.env.CARACAL_INSTALL_DIR ?? defaultCaracalInstallDir()
   const extra: string[] = []
-  const pnpmGlobal = spawnSync('pnpm', ['bin', '-g'], { encoding: 'utf8' })
-  if (pnpmGlobal.status === 0 && typeof pnpmGlobal.stdout === 'string') {
-    const dir = pnpmGlobal.stdout.trim()
-    if (dir) extra.push(dir)
+  const pnpm = resolvePnpm()
+  if (pnpm) {
+    const pnpmGlobal = spawnSyncTree(pnpm.cmd, [...pnpm.prefix, 'bin', '-g'], { encoding: 'utf8' })
+    if (pnpmGlobal.status === 0 && typeof pnpmGlobal.stdout === 'string') {
+      const dir = pnpmGlobal.stdout.trim()
+      if (dir) extra.push(dir)
+    }
   }
-  return caracalBinariesCore(installDir, extra)
+  return { installDir, paths: caracalBinariesCore(installDir, extra) }
+}
+
+function caracalBinaryDiscovery(ctx: PurgeContext): { installDir: string; paths: string[] } {
+  return (ctx.binaryDiscovery ??= discoverCaracalBinaries())
+}
+
+function sameDirectory(path: string, directory: string): boolean {
+  if (isWindowsRuntime()) {
+    return win32.resolve(win32.dirname(path)).toLowerCase() === win32.resolve(directory).toLowerCase()
+  }
+  const parent = resolve(dirname(path))
+  const target = resolve(directory)
+  return parent === target
 }
 
 const TARGETS: Target[] = [
@@ -424,15 +448,32 @@ const TARGETS: Target[] = [
   {
     id: 'binary',
     label: 'Uninstall Caracal binaries (DESTRUCTIVE)',
-    describe: () => {
-      const found = caracalBinariesPaths()
+    describe: (ctx) => {
+      const found = caracalBinaryDiscovery(ctx).paths
       if (found.length === 0) return '(no caracal binaries on $PATH)'
       return found.join(', ')
     },
-    available: () => caracalBinariesPaths().length > 0,
+    available: (ctx) => caracalBinaryDiscovery(ctx).paths.length > 0,
     run: async (ctx) => {
-      for (const bin of caracalBinariesPaths()) {
-        removePath(bin, ctx, `bin/${bin.split('/').pop()}`)
+      const discovery = caracalBinaryDiscovery(ctx)
+      let installedBinaryFound = false
+      for (const bin of discovery.paths) {
+        const label = `bin/${basename(bin)}`
+        if (sameDirectory(bin, discovery.installDir)) installedBinaryFound = true
+        if (ctx.dryRun && isRunningExecutable(bin)) {
+          process.stdout.write(`  ${style.label('[dry-run]')} schedule removal after exit ${style.code(label)}: ${bin}\n`)
+        } else if (!ctx.dryRun && deferRunningExecutableRemoval(bin)) {
+          process.stdout.write(`  ${style.success(SYMBOL.ok)} scheduled removal of ${style.code(label)} after exit: ${bin}\n`)
+        } else {
+          removePath(bin, ctx, label)
+        }
+      }
+      if (installedBinaryFound && isWindowsRuntime()) {
+        if (ctx.dryRun) {
+          process.stdout.write(`  ${style.label('[dry-run]')} remove from Windows user PATH: ${discovery.installDir}\n`)
+        } else if (removeWindowsUserPathEntry(discovery.installDir)) {
+          process.stdout.write(`  ${style.success(SYMBOL.ok)} removed from Windows user PATH: ${discovery.installDir}\n`)
+        }
       }
     },
   },

--- a/apps/runtime/src/commands/purge.ts
+++ b/apps/runtime/src/commands/purge.ts
@@ -457,12 +457,18 @@ const TARGETS: Target[] = [
     run: async (ctx) => {
       const discovery = caracalBinaryDiscovery(ctx)
       let installedBinaryFound = false
+      let installedPathCleanupDeferred = false
       for (const bin of discovery.paths) {
         const label = `bin/${basename(bin)}`
-        if (sameDirectory(bin, discovery.installDir)) installedBinaryFound = true
+        const installedHere = sameDirectory(bin, discovery.installDir)
+        if (installedHere) installedBinaryFound = true
         if (ctx.dryRun && isRunningExecutable(bin)) {
           process.stdout.write(`  ${style.label('[dry-run]')} schedule removal after exit ${style.code(label)}: ${bin}\n`)
-        } else if (!ctx.dryRun && deferRunningExecutableRemoval(bin)) {
+        } else if (
+          !ctx.dryRun &&
+          deferRunningExecutableRemoval(bin, { removeUserPathEntry: installedHere ? discovery.installDir : undefined })
+        ) {
+          if (installedHere) installedPathCleanupDeferred = true
           process.stdout.write(`  ${style.success(SYMBOL.ok)} scheduled removal of ${style.code(label)} after exit: ${bin}\n`)
         } else {
           removePath(bin, ctx, label)
@@ -471,7 +477,7 @@ const TARGETS: Target[] = [
       if (installedBinaryFound && isWindowsRuntime()) {
         if (ctx.dryRun) {
           process.stdout.write(`  ${style.label('[dry-run]')} remove from Windows user PATH: ${discovery.installDir}\n`)
-        } else if (removeWindowsUserPathEntry(discovery.installDir)) {
+        } else if (!installedPathCleanupDeferred && removeWindowsUserPathEntry(discovery.installDir)) {
           process.stdout.write(`  ${style.success(SYMBOL.ok)} removed from Windows user PATH: ${discovery.installDir}\n`)
         }
       }

--- a/apps/runtime/src/commands/purge.ts
+++ b/apps/runtime/src/commands/purge.ts
@@ -12,8 +12,8 @@ import { authMaintenanceUrl, configuredAuthDatabaseName } from './authStore.ts'
 import { defaultCaracalConfigDir } from '@caracalai/engine/runtime-config'
 import {
   caracalBinaries as caracalBinariesCore,
+  caracalInstallDirs,
   composeRun,
-  defaultCaracalInstallDir,
   installRuntimeAssets,
   listCaracalImages,
   removeFsPath,
@@ -85,7 +85,7 @@ interface PurgeContext {
   repoRoot: string | undefined
   composeAvailable: boolean
   dryRun: boolean
-  binaryDiscovery?: { installDir: string; paths: string[] }
+  binaryDiscovery?: { installDirs: string[]; paths: string[] }
 }
 
 interface SecretCleanupTarget {
@@ -280,21 +280,22 @@ function removePath(path: string, ctx: PurgeContext, label: string): void {
   process.stdout.write(`  ${style.success(SYMBOL.ok)} removed ${style.code(label)}: ${path}\n`)
 }
 
-function discoverCaracalBinaries(): { installDir: string; paths: string[] } {
-  const installDir = process.env.CARACAL_INSTALL_DIR ?? defaultCaracalInstallDir()
-  const extra: string[] = []
+function discoverCaracalBinaries(): { installDirs: string[]; paths: string[] } {
+  const installDirs = caracalInstallDirs()
+  const pnpmDirs: string[] = []
   const pnpm = resolvePnpm()
   if (pnpm) {
     const pnpmGlobal = spawnSyncTree(pnpm.cmd, [...pnpm.prefix, 'bin', '-g'], { encoding: 'utf8' })
     if (pnpmGlobal.status === 0 && typeof pnpmGlobal.stdout === 'string') {
       const dir = pnpmGlobal.stdout.trim()
-      if (dir) extra.push(dir)
+      if (dir) pnpmDirs.push(dir)
     }
   }
-  return { installDir, paths: caracalBinariesCore(installDir, extra) }
+  const [installDir, ...extraInstallDirs] = installDirs
+  return { installDirs, paths: caracalBinariesCore(installDir!, [...extraInstallDirs, ...pnpmDirs]) }
 }
 
-function caracalBinaryDiscovery(ctx: PurgeContext): { installDir: string; paths: string[] } {
+function caracalBinaryDiscovery(ctx: PurgeContext): { installDirs: string[]; paths: string[] } {
   return (ctx.binaryDiscovery ??= discoverCaracalBinaries())
 }
 
@@ -456,29 +457,29 @@ const TARGETS: Target[] = [
     available: (ctx) => caracalBinaryDiscovery(ctx).paths.length > 0,
     run: async (ctx) => {
       const discovery = caracalBinaryDiscovery(ctx)
-      let installedBinaryFound = false
-      let installedPathCleanupDeferred = false
+      const installedDirsFound = new Set<string>()
+      const deferredPathCleanup = new Set<string>()
       for (const bin of discovery.paths) {
         const label = `bin/${basename(bin)}`
-        const installedHere = sameDirectory(bin, discovery.installDir)
-        if (installedHere) installedBinaryFound = true
+        const installedDir = discovery.installDirs.find((directory) => sameDirectory(bin, directory))
+        if (installedDir) installedDirsFound.add(installedDir)
         if (ctx.dryRun && isRunningExecutable(bin)) {
           process.stdout.write(`  ${style.label('[dry-run]')} schedule removal after exit ${style.code(label)}: ${bin}\n`)
-        } else if (
-          !ctx.dryRun &&
-          deferRunningExecutableRemoval(bin, { removeUserPathEntry: installedHere ? discovery.installDir : undefined })
-        ) {
-          if (installedHere) installedPathCleanupDeferred = true
+        } else if (!ctx.dryRun && deferRunningExecutableRemoval(bin, { removeUserPathEntry: installedDir })) {
+          if (installedDir) deferredPathCleanup.add(installedDir)
           process.stdout.write(`  ${style.success(SYMBOL.ok)} scheduled removal of ${style.code(label)} after exit: ${bin}\n`)
         } else {
           removePath(bin, ctx, label)
         }
       }
-      if (installedBinaryFound && isWindowsRuntime()) {
-        if (ctx.dryRun) {
-          process.stdout.write(`  ${style.label('[dry-run]')} remove from Windows user PATH: ${discovery.installDir}\n`)
-        } else if (!installedPathCleanupDeferred && removeWindowsUserPathEntry(discovery.installDir)) {
-          process.stdout.write(`  ${style.success(SYMBOL.ok)} removed from Windows user PATH: ${discovery.installDir}\n`)
+      if (isWindowsRuntime()) {
+        for (const installDir of installedDirsFound) {
+          if (deferredPathCleanup.has(installDir)) continue
+          if (ctx.dryRun) {
+            process.stdout.write(`  ${style.label('[dry-run]')} remove from Windows user PATH: ${installDir}\n`)
+          } else if (removeWindowsUserPathEntry(installDir)) {
+            process.stdout.write(`  ${style.success(SYMBOL.ok)} removed from Windows user PATH: ${installDir}\n`)
+          }
         }
       }
     },

--- a/apps/runtime/src/processTree.ts
+++ b/apps/runtime/src/processTree.ts
@@ -127,24 +127,44 @@ export function isRunningExecutable(path: string, currentExecutable: string = pr
   return isWindows && resolve(path).toLowerCase() === resolve(currentExecutable).toLowerCase()
 }
 
+function windowsUserPathRemovalScript(directory: string): string[] {
+  const literalDirectory = directory.replace(/'/g, "''")
+  return [
+    '$pathChanged = $false',
+    "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
+    'if ($null -ne $current) {',
+    `  $entries = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ine '${literalDirectory}' })`,
+    "  $next = $entries -join ';'",
+    "  if ($next -ne $current) { [Environment]::SetEnvironmentVariable('Path', $next, 'User'); $pathChanged = $true }",
+    '}',
+  ]
+}
+
+export interface DeferredExecutableRemovalOptions {
+  currentExecutable?: string
+  currentPid?: number
+  removeUserPathEntry?: string
+}
+
 // Windows keeps a running executable locked. Hand its removal to a detached
 // PowerShell process that waits for this process to exit before deleting it.
-export function deferRunningExecutableRemoval(
-  path: string,
-  currentExecutable: string = process.execPath,
-  currentPid: number = process.pid,
-): boolean {
+export function deferRunningExecutableRemoval(path: string, options: DeferredExecutableRemovalOptions = {}): boolean {
+  const currentExecutable = options.currentExecutable ?? process.execPath
+  const currentPid = options.currentPid ?? process.pid
   if (!isRunningExecutable(path, currentExecutable)) return false
   const literalPath = path.replace(/'/g, "''")
   const script = [
     "$ErrorActionPreference = 'SilentlyContinue'",
     `Wait-Process -Id ${currentPid}`,
+    '$removed = $false',
     'for ($attempt = 0; $attempt -lt 50; $attempt++) {',
     `  Remove-Item -LiteralPath '${literalPath}' -Force`,
-    `  if (-not (Test-Path -LiteralPath '${literalPath}')) { exit 0 }`,
+    `  if (-not (Test-Path -LiteralPath '${literalPath}')) { $removed = $true; break }`,
     '  Start-Sleep -Milliseconds 100',
     '}',
-    'exit 1',
+    'if (-not $removed) { exit 1 }',
+    ...(options.removeUserPathEntry ? windowsUserPathRemovalScript(options.removeUserPathEntry) : []),
+    'exit 0',
   ].join('\n')
   const encoded = Buffer.from(script, 'utf16le').toString('base64')
   const powershell = windowsPowershell()
@@ -160,15 +180,9 @@ export function deferRunningExecutableRemoval(
 
 export function removeWindowsUserPathEntry(directory: string): boolean {
   if (!isWindows) return false
-  const literalDirectory = directory.replace(/'/g, "''")
-  const script = [
-    "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
-    'if ($null -eq $current) { exit 0 }',
-    `$entries = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ine '${literalDirectory}' })`,
-    "$next = $entries -join ';'",
-    "if ($next -ne $current) { [Environment]::SetEnvironmentVariable('Path', $next, 'User') }",
-  ].join('\n')
+  const script = [...windowsUserPathRemovalScript(directory), 'if ($pathChanged) { exit 0 }', 'exit 2'].join('\n')
   const result = runWindowsPowershell(script)
+  if (!result.error && result.status === 2) return false
   if (result.error || result.status !== 0) throw new Error('failed to remove the Caracal install directory from the Windows user PATH')
   return true
 }

--- a/apps/runtime/src/processTree.ts
+++ b/apps/runtime/src/processTree.ts
@@ -133,7 +133,7 @@ function windowsUserPathRemovalScript(directory: string): string[] {
     '$pathChanged = $false',
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     'if ($null -ne $current) {',
-    `  $entries = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ine '${literalDirectory}' })`,
+    `  $entries = @($current -split ';' | Where-Object { $_ -ine '${literalDirectory}' })`,
     "  $next = $entries -join ';'",
     "  if ($next -ne $current) { [Environment]::SetEnvironmentVariable('Path', $next, 'User'); $pathChanged = $true }",
     '}',

--- a/apps/runtime/src/processTree.ts
+++ b/apps/runtime/src/processTree.ts
@@ -5,7 +5,7 @@
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions, type SpawnSyncReturns } from 'node:child_process'
 import { existsSync, statSync } from 'node:fs'
-import { delimiter, join } from 'node:path'
+import { delimiter, join, resolve, win32 } from 'node:path'
 
 const isWindows = process.platform === 'win32'
 // pnpm ships as a bare binary on POSIX; on Windows it is pnpm.exe (standalone install)
@@ -104,4 +104,71 @@ export function killTree(child: ChildProcess, signal: NodeJS.Signals): void {
   } catch {
     /* already gone */
   }
+}
+
+function windowsPowershell(): string {
+  const windowsDir = process.env.SystemRoot || process.env.WINDIR
+  return windowsDir ? win32.join(windowsDir, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe') : 'powershell.exe'
+}
+
+function runWindowsPowershell(script: string): SpawnSyncReturns<string | Buffer> {
+  return spawnSync(
+    windowsPowershell(),
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')],
+    { stdio: 'ignore', windowsHide: true },
+  )
+}
+
+export function isWindowsRuntime(): boolean {
+  return isWindows
+}
+
+export function isRunningExecutable(path: string, currentExecutable: string = process.execPath): boolean {
+  return isWindows && resolve(path).toLowerCase() === resolve(currentExecutable).toLowerCase()
+}
+
+// Windows keeps a running executable locked. Hand its removal to a detached
+// PowerShell process that waits for this process to exit before deleting it.
+export function deferRunningExecutableRemoval(
+  path: string,
+  currentExecutable: string = process.execPath,
+  currentPid: number = process.pid,
+): boolean {
+  if (!isRunningExecutable(path, currentExecutable)) return false
+  const literalPath = path.replace(/'/g, "''")
+  const script = [
+    "$ErrorActionPreference = 'SilentlyContinue'",
+    `Wait-Process -Id ${currentPid}`,
+    'for ($attempt = 0; $attempt -lt 50; $attempt++) {',
+    `  Remove-Item -LiteralPath '${literalPath}' -Force`,
+    `  if (-not (Test-Path -LiteralPath '${literalPath}')) { exit 0 }`,
+    '  Start-Sleep -Milliseconds 100',
+    '}',
+    'exit 1',
+  ].join('\n')
+  const encoded = Buffer.from(script, 'utf16le').toString('base64')
+  const powershell = windowsPowershell()
+  const literalPowershell = powershell.replace(/'/g, "''")
+  const launcher = [
+    `$worker = Start-Process -FilePath '${literalPowershell}' -ArgumentList @('-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', '${encoded}') -WindowStyle Hidden -PassThru`,
+    'if ($null -eq $worker) { exit 1 }',
+  ].join('\n')
+  const launch = runWindowsPowershell(launcher)
+  if (launch.error || launch.status !== 0) throw new Error('failed to schedule removal of the running Caracal executable')
+  return true
+}
+
+export function removeWindowsUserPathEntry(directory: string): boolean {
+  if (!isWindows) return false
+  const literalDirectory = directory.replace(/'/g, "''")
+  const script = [
+    "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
+    'if ($null -eq $current) { exit 0 }',
+    `$entries = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -ine '${literalDirectory}' })`,
+    "$next = $entries -join ';'",
+    "if ($next -ne $current) { [Environment]::SetEnvironmentVariable('Path', $next, 'User') }",
+  ].join('\n')
+  const result = runWindowsPowershell(script)
+  if (result.error || result.status !== 0) throw new Error('failed to remove the Caracal install directory from the Windows user PATH')
+  return true
 }

--- a/packages/engine/src/stack.ts
+++ b/packages/engine/src/stack.ts
@@ -385,6 +385,32 @@ export function defaultCaracalInstallDir(
   return env.HOME ? posix.join(env.HOME, '.local', 'bin') : '/usr/local/bin'
 }
 
+export function caracalInstallDirs(
+  targetPlatform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+  executable: string = process.execPath,
+): string[] {
+  const path = targetPlatform === 'win32' ? win32 : posix
+  const dirs: string[] = []
+  const seen = new Set<string>()
+  const add = (directory: string | undefined) => {
+    if (!directory) return
+    const normalized = path.normalize(directory)
+    const key = targetPlatform === 'win32' ? normalized.toLowerCase() : normalized
+    if (seen.has(key)) return
+    seen.add(key)
+    dirs.push(normalized)
+  }
+
+  add(env.CARACAL_INSTALL_DIR)
+  const prefix = env.CARACAL_PREFIX || (targetPlatform === 'win32' ? undefined : env.PREFIX)
+  if (prefix) add(path.join(prefix, 'bin'))
+  if (['caracal', 'caracal.exe'].includes(path.basename(executable).toLowerCase())) add(path.dirname(executable))
+  add(defaultCaracalInstallDir(targetPlatform, env, home))
+  return dirs
+}
+
 export function caracalBinaries(
   installDir: string,
   extraDirs: readonly string[] = [],

--- a/packages/engine/src/stack.ts
+++ b/packages/engine/src/stack.ts
@@ -5,6 +5,8 @@
 
 import { rmSync, statSync, existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { homedir } from 'node:os'
+import { join, posix, win32 } from 'node:path'
 import { runExec } from './run.js'
 import { authorizeControlManagementAccess } from './controlAccess.js'
 import {
@@ -371,13 +373,30 @@ export function removeFsPath(path: string): { removed: boolean } {
   return { removed: true }
 }
 
-export function caracalBinaries(installDir: string, extraDirs: readonly string[] = []): string[] {
+export function defaultCaracalInstallDir(
+  targetPlatform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string {
+  if (targetPlatform === 'win32') {
+    const base = env.LOCALAPPDATA || env.ProgramData || win32.join(home, 'AppData', 'Local')
+    return win32.join(base, 'Programs', 'caracal')
+  }
+  return env.HOME ? posix.join(env.HOME, '.local', 'bin') : '/usr/local/bin'
+}
+
+export function caracalBinaries(
+  installDir: string,
+  extraDirs: readonly string[] = [],
+  targetPlatform: NodeJS.Platform = process.platform,
+): string[] {
   const dirs = new Set<string>([installDir, ...extraDirs])
   const found: string[] = []
+  const names = targetPlatform === 'win32' ? ['caracal.exe', 'caracal', 'caracal.cmd', 'caracal.ps1'] : ['caracal']
   for (const dir of dirs) {
-    for (const name of ['caracal', 'caracal-web']) {
-      const p = `${dir}/${name}`
-      if (existsSync(p)) found.push(p)
+    for (const name of names) {
+      const path = join(dir, name)
+      if (existsSync(path)) found.push(path)
     }
   }
   return found

--- a/tests/typescript/unit/engine/stack.test.ts
+++ b/tests/typescript/unit/engine/stack.test.ts
@@ -5,10 +5,11 @@
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   caracalBinaries,
+  defaultCaracalInstallDir,
   defaultServiceProbes,
   listCaracalImages,
   removeFsPath,
@@ -109,14 +110,31 @@ describe('stack cleanup helpers', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('finds Caracal binaries across install and extra directories and preserves purge ordering', async () => {
+  it('resolves platform install directories and binary names', () => {
+    expect(defaultCaracalInstallDir('win32', { LOCALAPPDATA: 'C:\\Users\\dev\\AppData\\Local' }, 'C:\\Users\\dev')).toBe(
+      win32.join('C:\\Users\\dev\\AppData\\Local', 'Programs', 'caracal'),
+    )
+    expect(defaultCaracalInstallDir('linux', { HOME: '/home/dev' }, '/home/dev')).toBe('/home/dev/.local/bin')
+    expect(defaultCaracalInstallDir('linux', {}, '/')).toBe('/usr/local/bin')
+
     const install = mkdtempSync(join(tmpdir(), 'caracal-bin-install-'))
     const extra = mkdtempSync(join(tmpdir(), 'caracal-bin-extra-'))
     writeFileSync(join(install, 'caracal'), '')
-    writeFileSync(join(extra, 'caracal-web'), '')
-    const events: string[] = []
+    writeFileSync(join(extra, 'caracal.exe'), '')
+    writeFileSync(join(extra, 'caracal.cmd'), '')
 
-    expect(caracalBinaries(install, [extra])).toEqual([join(install, 'caracal'), join(extra, 'caracal-web')])
+    expect(caracalBinaries(install, [extra], 'linux')).toEqual([join(install, 'caracal')])
+    expect(caracalBinaries(install, [extra], 'win32')).toEqual([
+      join(install, 'caracal'),
+      join(extra, 'caracal.exe'),
+      join(extra, 'caracal.cmd'),
+    ])
+    rmSync(install, { recursive: true, force: true })
+    rmSync(extra, { recursive: true, force: true })
+  })
+
+  it('preserves purge ordering', async () => {
+    const events: string[] = []
 
     await stackPurge({
       steps: [
@@ -139,7 +157,5 @@ describe('stack cleanup helpers', () => {
     })
 
     expect(events).toEqual(['start:one', 'run:one', 'end:one', 'start:two', 'run:two', 'end:two'])
-    rmSync(install, { recursive: true, force: true })
-    rmSync(extra, { recursive: true, force: true })
   })
 })

--- a/tests/typescript/unit/engine/stack.test.ts
+++ b/tests/typescript/unit/engine/stack.test.ts
@@ -9,6 +9,7 @@ import { join, win32 } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   caracalBinaries,
+  caracalInstallDirs,
   defaultCaracalInstallDir,
   defaultServiceProbes,
   listCaracalImages,
@@ -116,6 +117,16 @@ describe('stack cleanup helpers', () => {
     )
     expect(defaultCaracalInstallDir('linux', { HOME: '/home/dev' }, '/home/dev')).toBe('/home/dev/.local/bin')
     expect(defaultCaracalInstallDir('linux', {}, '/')).toBe('/usr/local/bin')
+
+    expect(
+      caracalInstallDirs(
+        'win32',
+        { CARACAL_INSTALL_DIR: 'C:\\Explicit', CARACAL_PREFIX: 'C:\\Tools', LOCALAPPDATA: 'C:\\Local' },
+        'C:\\Users\\dev',
+        'C:\\Running\\caracal.exe',
+      ),
+    ).toEqual(['C:\\Explicit', 'C:\\Tools\\bin', 'C:\\Running', 'C:\\Local\\Programs\\caracal'])
+    expect(caracalInstallDirs('linux', { PREFIX: '/opt/caracal' }, '/', '/usr/bin/node')).toEqual(['/opt/caracal/bin', '/usr/local/bin'])
 
     const install = mkdtempSync(join(tmpdir(), 'caracal-bin-install-'))
     const extra = mkdtempSync(join(tmpdir(), 'caracal-bin-extra-'))

--- a/tests/typescript/unit/runtime/processTree.test.ts
+++ b/tests/typescript/unit/runtime/processTree.test.ts
@@ -45,7 +45,7 @@ function fakeChild(pid: number | undefined): ChildProcess {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  spawnMock.mockReturnValue({ on: vi.fn(), kill: vi.fn(), pid: 4321 })
+  spawnMock.mockReturnValue({ on: vi.fn(), unref: vi.fn(), kill: vi.fn(), pid: 4321 })
   spawnSyncMock.mockReturnValue({ status: 0 })
   existsSyncMock.mockReturnValue(false)
   statSyncMock.mockReturnValue({ isFile: () => true })
@@ -137,5 +137,62 @@ describe('resolvePnpm', () => {
     delete process.env.npm_execpath
     process.env.PATH = 'shims'
     expect(mod.resolvePnpm()).toBeUndefined()
+  })
+})
+
+describe('deferRunningExecutableRemoval', () => {
+  it('schedules the running Windows executable for removal after exit', async () => {
+    process.env.SystemRoot = String.raw`C:\Windows`
+    const mod = await loadFor('win32')
+    expect(
+      mod.deferRunningExecutableRemoval(
+        String.raw`C:\Program Files\Caracal\caracal.exe`,
+        String.raw`c:\program files\caracal\CARACAL.EXE`,
+        1234,
+      ),
+    ).toBe(true)
+
+    const [command, args, options] = spawnSyncMock.mock.calls[0] as [string, string[], Record<string, unknown>]
+    expect(command).toBe(String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`)
+    expect(args.slice(0, -1)).toEqual(['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand'])
+    const launcher = Buffer.from(args.at(-1)!, 'base64').toString('utf16le')
+    expect(launcher).toContain('Start-Process')
+    expect(launcher).toContain('-WindowStyle Hidden')
+    const cleanup = /'-EncodedCommand', '([^']+)'/.exec(launcher)?.[1]
+    expect(cleanup).toBeDefined()
+    const script = Buffer.from(cleanup!, 'base64').toString('utf16le')
+    expect(script).toContain('Wait-Process -Id 1234')
+    expect(script).toContain("Remove-Item -LiteralPath 'C:\\Program Files\\Caracal\\caracal.exe' -Force")
+    expect(script).toContain('Start-Sleep -Milliseconds 100')
+    expect(options).toMatchObject({ stdio: 'ignore', windowsHide: true })
+  })
+
+  it('does not defer a different executable or any POSIX executable', async () => {
+    let mod = await loadFor('win32')
+    expect(mod.deferRunningExecutableRemoval('C:\\caracal.exe', 'C:\\node.exe', 1234)).toBe(false)
+    mod = await loadFor('linux')
+    expect(mod.deferRunningExecutableRemoval('/usr/local/bin/caracal', '/usr/local/bin/caracal', 1234)).toBe(false)
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('removeWindowsUserPathEntry', () => {
+  it('removes the install directory from the persistent Windows user PATH', async () => {
+    process.env.SystemRoot = String.raw`C:\Windows`
+    const mod = await loadFor('win32')
+
+    expect(mod.removeWindowsUserPathEntry(String.raw`C:\Users\O'Brien\Programs\caracal`)).toBe(true)
+
+    const [, args] = spawnSyncMock.mock.calls[0] as [string, string[]]
+    const script = Buffer.from(args.at(-1)!, 'base64').toString('utf16le')
+    expect(script).toContain("GetEnvironmentVariable('Path', 'User')")
+    expect(script).toContain(String.raw`C:\Users\O''Brien\Programs\caracal`)
+    expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
+  })
+
+  it('does not mutate PATH on POSIX', async () => {
+    const mod = await loadFor('linux')
+    expect(mod.removeWindowsUserPathEntry('/usr/local/bin')).toBe(false)
+    expect(spawnSyncMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/typescript/unit/runtime/processTree.test.ts
+++ b/tests/typescript/unit/runtime/processTree.test.ts
@@ -145,11 +145,11 @@ describe('deferRunningExecutableRemoval', () => {
     process.env.SystemRoot = String.raw`C:\Windows`
     const mod = await loadFor('win32')
     expect(
-      mod.deferRunningExecutableRemoval(
-        String.raw`C:\Program Files\Caracal\caracal.exe`,
-        String.raw`c:\program files\caracal\CARACAL.EXE`,
-        1234,
-      ),
+      mod.deferRunningExecutableRemoval(String.raw`C:\Program Files\Caracal\caracal.exe`, {
+        currentExecutable: String.raw`c:\program files\caracal\CARACAL.EXE`,
+        currentPid: 1234,
+        removeUserPathEntry: String.raw`C:\Program Files\Caracal`,
+      }),
     ).toBe(true)
 
     const [command, args, options] = spawnSyncMock.mock.calls[0] as [string, string[], Record<string, unknown>]
@@ -164,14 +164,21 @@ describe('deferRunningExecutableRemoval', () => {
     expect(script).toContain('Wait-Process -Id 1234')
     expect(script).toContain("Remove-Item -LiteralPath 'C:\\Program Files\\Caracal\\caracal.exe' -Force")
     expect(script).toContain('Start-Sleep -Milliseconds 100')
+    expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
+    expect(script.indexOf('if (-not $removed) { exit 1 }')).toBeLessThan(script.indexOf("SetEnvironmentVariable('Path', $next, 'User')"))
     expect(options).toMatchObject({ stdio: 'ignore', windowsHide: true })
   })
 
   it('does not defer a different executable or any POSIX executable', async () => {
     let mod = await loadFor('win32')
-    expect(mod.deferRunningExecutableRemoval('C:\\caracal.exe', 'C:\\node.exe', 1234)).toBe(false)
+    expect(mod.deferRunningExecutableRemoval('C:\\caracal.exe', { currentExecutable: 'C:\\node.exe', currentPid: 1234 })).toBe(false)
     mod = await loadFor('linux')
-    expect(mod.deferRunningExecutableRemoval('/usr/local/bin/caracal', '/usr/local/bin/caracal', 1234)).toBe(false)
+    expect(
+      mod.deferRunningExecutableRemoval('/usr/local/bin/caracal', {
+        currentExecutable: '/usr/local/bin/caracal',
+        currentPid: 1234,
+      }),
+    ).toBe(false)
     expect(spawnSyncMock).not.toHaveBeenCalled()
   })
 })
@@ -194,5 +201,11 @@ describe('removeWindowsUserPathEntry', () => {
     const mod = await loadFor('linux')
     expect(mod.removeWindowsUserPathEntry('/usr/local/bin')).toBe(false)
     expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('reports when the Windows user PATH did not change', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 2 })
+    const mod = await loadFor('win32')
+    expect(mod.removeWindowsUserPathEntry(String.raw`C:\Programs\caracal`)).toBe(false)
   })
 })

--- a/tests/typescript/unit/runtime/processTree.test.ts
+++ b/tests/typescript/unit/runtime/processTree.test.ts
@@ -195,6 +195,17 @@ describe('removeWindowsUserPathEntry', () => {
     expect(script).toContain("GetEnvironmentVariable('Path', 'User')")
     expect(script).toContain(String.raw`C:\Users\O''Brien\Programs\caracal`)
     expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
+    expect(script).toContain("$current -split ';' | Where-Object { $_ -ine 'C:\\Users\\O''Brien\\Programs\\caracal' }")
+    expect(script).not.toContain('IsNullOrWhiteSpace')
+  })
+
+  it('preserves unrelated empty PATH entries while removing only the install directory', async () => {
+    const mod = await loadFor('win32')
+    mod.removeWindowsUserPathEntry(String.raw`C:\Caracal`)
+
+    const [, args] = spawnSyncMock.mock.calls[0] as [string, string[]]
+    const script = Buffer.from(args.at(-1)!, 'base64').toString('utf16le')
+    expect(script).toContain("$current -split ';' | Where-Object { $_ -ine 'C:\\Caracal' }")
   })
 
   it('does not mutate PATH on POSIX', async () => {

--- a/tests/typescript/unit/runtime/purge.test.ts
+++ b/tests/typescript/unit/runtime/purge.test.ts
@@ -49,7 +49,7 @@ const engineMocks = vi.hoisted(() => ({
   removeImages: vi.fn(() => Promise.resolve(0)),
   runtimePaths: vi.fn(),
   caracalBinaries: vi.fn((): string[] => []),
-  defaultCaracalInstallDir: vi.fn(() => 'C:\\Caracal'),
+  caracalInstallDirs: vi.fn(() => ['C:\\Caracal']),
 }))
 
 const spawnSyncMock = vi.hoisted(() => vi.fn())
@@ -121,7 +121,7 @@ describe('purgeCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     engineMocks.caracalBinaries.mockReturnValue([])
-    engineMocks.defaultCaracalInstallDir.mockReturnValue('C:\\Caracal')
+    engineMocks.caracalInstallDirs.mockReturnValue(['C:\\Caracal'])
     processTreeMocks.deferRunningExecutableRemoval.mockReturnValue(false)
     processTreeMocks.isRunningExecutable.mockReturnValue(false)
     processTreeMocks.isWindowsRuntime.mockReturnValue(false)
@@ -434,7 +434,7 @@ describe('purgeCommand', () => {
 
     await purgeCommand(['binary', '--yes'])
 
-    expect(engineMocks.defaultCaracalInstallDir).toHaveBeenCalled()
+    expect(engineMocks.caracalInstallDirs).toHaveBeenCalled()
     expect(processTreeMocks.spawnSyncTree).toHaveBeenCalledWith('pnpm.cmd', ['bin', '-g'], { encoding: 'utf8' })
     expect(engineMocks.caracalBinaries).toHaveBeenCalledTimes(1)
     expect(engineMocks.caracalBinaries).toHaveBeenCalledWith('C:\\Caracal', ['C:\\pnpm-global'])
@@ -444,6 +444,29 @@ describe('purgeCommand', () => {
     expect(engineMocks.removeFsPath).not.toHaveBeenCalledWith(binPath)
     expect(processTreeMocks.removeWindowsUserPathEntry).not.toHaveBeenCalled()
     expect(output()).toContain('scheduled removal')
+  })
+
+  it('discovers and cleans up a custom-prefix Windows installation', async () => {
+    const prefixBin = 'C:\\Tools\\bin'
+    const binPath = `${prefixBin}\\caracal.exe`
+    engineMocks.caracalInstallDirs.mockReturnValue([prefixBin, 'C:\\Caracal'])
+    engineMocks.caracalBinaries.mockReturnValue([binPath])
+    processTreeMocks.isWindowsRuntime.mockReturnValue(true)
+
+    await purgeCommand(['binary', '--yes'])
+
+    expect(engineMocks.caracalBinaries).toHaveBeenCalledWith(prefixBin, ['C:\\Caracal'])
+    expect(processTreeMocks.removeWindowsUserPathEntry).toHaveBeenCalledWith(prefixBin)
+  })
+
+  it('does not clean persistent PATH for a pnpm-global shim', async () => {
+    engineMocks.caracalInstallDirs.mockReturnValue(['C:\\Caracal'])
+    engineMocks.caracalBinaries.mockReturnValue(['C:\\pnpm-global\\caracal.cmd'])
+    processTreeMocks.isWindowsRuntime.mockReturnValue(true)
+
+    await purgeCommand(['binary', '--yes'])
+
+    expect(processTreeMocks.removeWindowsUserPathEntry).not.toHaveBeenCalled()
   })
 
   it('does not report PATH cleanup when the entry was absent', async () => {

--- a/tests/typescript/unit/runtime/purge.test.ts
+++ b/tests/typescript/unit/runtime/purge.test.ts
@@ -49,9 +49,18 @@ const engineMocks = vi.hoisted(() => ({
   removeImages: vi.fn(() => Promise.resolve(0)),
   runtimePaths: vi.fn(),
   caracalBinaries: vi.fn((): string[] => []),
+  defaultCaracalInstallDir: vi.fn(() => 'C:\\Caracal'),
 }))
 
 const spawnSyncMock = vi.hoisted(() => vi.fn())
+const processTreeMocks = vi.hoisted(() => ({
+  deferRunningExecutableRemoval: vi.fn(() => false),
+  isRunningExecutable: vi.fn(() => false),
+  isWindowsRuntime: vi.fn(() => false),
+  removeWindowsUserPathEntry: vi.fn(() => true),
+  resolvePnpm: vi.fn(() => undefined),
+  spawnSyncTree: vi.fn(),
+}))
 
 const promptAnswers = vi.hoisted(() => ({ queue: [] as string[] }))
 
@@ -68,6 +77,8 @@ vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('node:child_process')>()),
   spawnSync: spawnSyncMock,
 }))
+
+vi.mock('../../../../apps/runtime/src/processTree.ts', () => processTreeMocks)
 
 vi.mock('@caracalai/engine', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@caracalai/engine')>()
@@ -109,6 +120,13 @@ describe('purgeCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    engineMocks.caracalBinaries.mockReturnValue([])
+    engineMocks.defaultCaracalInstallDir.mockReturnValue('C:\\Caracal')
+    processTreeMocks.deferRunningExecutableRemoval.mockReturnValue(false)
+    processTreeMocks.isRunningExecutable.mockReturnValue(false)
+    processTreeMocks.isWindowsRuntime.mockReturnValue(false)
+    processTreeMocks.removeWindowsUserPathEntry.mockReturnValue(true)
+    processTreeMocks.resolvePnpm.mockReturnValue(undefined)
     promptAnswers.queue.length = 0
     repoRoot = mkdtempSync(join(tmpdir(), 'caracal-purge-repo-'))
     runtimeHome = mkdtempSync(join(tmpdir(), 'caracal-purge-runtime-'))
@@ -403,5 +421,41 @@ describe('purgeCommand', () => {
     await purgeCommand(['binary', '--yes'])
     const removed = engineMocks.removeFsPath.mock.calls.map((call) => String(call[0]))
     expect(removed).toContain(binPath)
+  })
+
+  it('uses platform discovery and defers removal of the running Windows executable', async () => {
+    const binPath = 'C:\\Caracal\\caracal.exe'
+    engineMocks.caracalBinaries.mockReturnValue([binPath])
+    processTreeMocks.resolvePnpm.mockReturnValue({ cmd: 'pnpm.cmd', prefix: [] })
+    processTreeMocks.spawnSyncTree.mockReturnValue({ status: 0, stdout: 'C:\\pnpm-global\n' })
+    processTreeMocks.isRunningExecutable.mockReturnValue(true)
+    processTreeMocks.isWindowsRuntime.mockReturnValue(true)
+    processTreeMocks.deferRunningExecutableRemoval.mockReturnValue(true)
+
+    await purgeCommand(['binary', '--yes'])
+
+    expect(engineMocks.defaultCaracalInstallDir).toHaveBeenCalled()
+    expect(processTreeMocks.spawnSyncTree).toHaveBeenCalledWith('pnpm.cmd', ['bin', '-g'], { encoding: 'utf8' })
+    expect(engineMocks.caracalBinaries).toHaveBeenCalledTimes(1)
+    expect(engineMocks.caracalBinaries).toHaveBeenCalledWith('C:\\Caracal', ['C:\\pnpm-global'])
+    expect(processTreeMocks.deferRunningExecutableRemoval).toHaveBeenCalledWith(binPath)
+    expect(engineMocks.removeFsPath).not.toHaveBeenCalledWith(binPath)
+    expect(processTreeMocks.removeWindowsUserPathEntry).toHaveBeenCalledWith('C:\\Caracal')
+    expect(output()).toContain('scheduled removal')
+  })
+
+  it('previews deferred removal and PATH cleanup without performing either action', async () => {
+    const binPath = 'C:\\Caracal\\caracal.exe'
+    engineMocks.caracalBinaries.mockReturnValue([binPath])
+    processTreeMocks.isRunningExecutable.mockReturnValue(true)
+    processTreeMocks.isWindowsRuntime.mockReturnValue(true)
+
+    await purgeCommand(['binary', '--dry-run'])
+
+    expect(output()).toContain('[dry-run] schedule removal after exit')
+    expect(output()).toContain('[dry-run] remove from Windows user PATH')
+    expect(processTreeMocks.deferRunningExecutableRemoval).not.toHaveBeenCalled()
+    expect(processTreeMocks.removeWindowsUserPathEntry).not.toHaveBeenCalled()
+    expect(engineMocks.removeFsPath).not.toHaveBeenCalledWith(binPath)
   })
 })

--- a/tests/typescript/unit/runtime/purge.test.ts
+++ b/tests/typescript/unit/runtime/purge.test.ts
@@ -438,10 +438,24 @@ describe('purgeCommand', () => {
     expect(processTreeMocks.spawnSyncTree).toHaveBeenCalledWith('pnpm.cmd', ['bin', '-g'], { encoding: 'utf8' })
     expect(engineMocks.caracalBinaries).toHaveBeenCalledTimes(1)
     expect(engineMocks.caracalBinaries).toHaveBeenCalledWith('C:\\Caracal', ['C:\\pnpm-global'])
-    expect(processTreeMocks.deferRunningExecutableRemoval).toHaveBeenCalledWith(binPath)
+    expect(processTreeMocks.deferRunningExecutableRemoval).toHaveBeenCalledWith(binPath, {
+      removeUserPathEntry: 'C:\\Caracal',
+    })
     expect(engineMocks.removeFsPath).not.toHaveBeenCalledWith(binPath)
-    expect(processTreeMocks.removeWindowsUserPathEntry).toHaveBeenCalledWith('C:\\Caracal')
+    expect(processTreeMocks.removeWindowsUserPathEntry).not.toHaveBeenCalled()
     expect(output()).toContain('scheduled removal')
+  })
+
+  it('does not report PATH cleanup when the entry was absent', async () => {
+    const binPath = 'C:\\Caracal\\caracal.cmd'
+    engineMocks.caracalBinaries.mockReturnValue([binPath])
+    processTreeMocks.isWindowsRuntime.mockReturnValue(true)
+    processTreeMocks.removeWindowsUserPathEntry.mockReturnValue(false)
+
+    await purgeCommand(['binary', '--yes'])
+
+    expect(processTreeMocks.removeWindowsUserPathEntry).toHaveBeenCalledWith('C:\\Caracal')
+    expect(output()).not.toContain('removed from Windows user PATH')
   })
 
   it('previews deferred removal and PATH cleanup without performing either action', async () => {


### PR DESCRIPTION
## Summary

* align Caracal binary discovery with the Windows and POSIX installers
* discover Windows executables and pnpm global shims using platform-native paths
* resolve pnpm through the platform-aware launcher instead of a bare `spawnSync`
* defer removal of a running Windows executable until the process exits
* cache binary discovery across purge availability, description, and execution
* remove the Windows user PATH entry only after the installed executable is removed
* make dry-run output accurately describe deferred cleanup

## Problem

`caracal purge binary` did not work on Windows installations.

Discovery defaulted to `~/.local/bin` and searched only for `caracal` and the stale `caracal-web` name, so it did not find `caracal.exe` in the directory used by the Windows installer. Because discovery returned no binaries, the target was reported as unavailable and omitted from the purge plan. Setting `CARACAL_INSTALL_DIR` did not resolve the problem because the expected executable name was still missing.

The pnpm global lookup also called `spawnSync('pnpm', ...)` directly. On Windows, pnpm is commonly exposed through a `.cmd` shim, causing the lookup to fail with `ENOENT` and then be silently ignored by the existing `status === 0` guard.

Additionally, binary paths were constructed using a hardcoded `/` separator instead of `path.join`. This caused an existing engine test to fail on Windows while remaining undetected by Linux-only CI.

Finally, Windows locks a running executable image, so `caracal.exe` cannot delete itself during `caracal purge binary`.

## Implementation

Binary discovery now mirrors the supported platform installers:

* Windows: `%LOCALAPPDATA%`, `%ProgramData%`, or the user-home fallback under `Programs\caracal`
* POSIX: `$HOME/.local/bin` or `/usr/local/bin`

Windows discovery checks `caracal.exe`, `caracal`, `caracal.cmd`, and `caracal.ps1`. Paths are constructed using platform-native path helpers.

The pnpm global directory is resolved through the existing `resolvePnpm()` and `spawnSyncTree()` helpers, which handle Windows command shims correctly. Discovery is cached so purge availability, description, and execution share one lookup.

When the purge target is the currently running executable, Caracal launches a detached PowerShell worker through an encoded command. The worker waits for the Caracal process to exit, retries deletion for up to five seconds while Windows releases the executable lock, and removes the install directory from the persistent Windows user PATH only after confirming that the executable was deleted.

If deletion fails, the PATH entry remains intact. Directly removable binaries continue to use the existing removal path, and PATH cleanup reports success only when the stored user PATH actually changes.

Dry-run output now distinguishes deferred executable removal from immediate file removal and previews the associated PATH cleanup accurately.

`caracal purge all` on Windows now also removes the install directory from the user PATH, matching the behavior of `install.ps1 -Uninstall`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Caracal binary discovery across configured installation locations, including pnpm’s global directory.
  - Added Windows support for `.exe` and `.cmd` binaries.
  - Running Windows executables are now removed safely after they exit.
  - Windows PATH entries are cleaned up selectively while preserving unrelated entries.
  - Dry-run purges continue to avoid making cleanup changes.

- **Bug Fixes**
  - Improved purge handling for multiple installation directories and custom prefixes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->