### PR TITLE
fix(operator): recover approved plans after credentials expire

### DIFF
--- a/apps/api/src/operator-plan-secrets.ts
+++ b/apps/api/src/operator-plan-secrets.ts
@@ -10,8 +10,9 @@ import { PROVIDER_KINDS, PUBLIC_PROVIDER_CONFIG_KEYS, type ProviderKind } from '
 // refusing pathological payloads.
 export const CREDENTIAL_VALUE_MAX = 16384
 
-// How long pasted credentials stay available for an undecided plan. A plan the operator
-// abandons leaves nothing behind: an expired row is treated as absent and swept on write.
+// How long pasted credentials stay available for a pending or approved plan. Approval does not
+// make secret material permanent: an expired value is treated as absent and may be pasted again
+// for the same immutable plan step, while abandoned values are swept on write.
 export const PLAN_SECRET_TTL_MS = 30 * 60 * 1000
 
 function isProviderKind(value: unknown): value is ProviderKind {

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -1716,11 +1716,12 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
   })
 
   // Accepts one step's credentials pasted through the console's secure prompt. The values are
-  // validated against exactly the fields the step requires, sealed into the vault, and never
-  // echoed; a re-paste before the plan is decided replaces the earlier values. When the vault
-  // then satisfies the whole plan in an engaged autopilot conversation, Caracal re-evaluates the
-  // approval it deferred at plan time. A failed guardian review still leaves the plan waiting for
-  // a human decision.
+  // validated against exactly the fields the immutable step requires, sealed into the vault, and
+  // never echoed. A re-paste may replace an earlier value before approval or recover an approved,
+  // still-unspent plan after its short-lived values expire. Rejected and spent plans stay closed.
+  // When the vault satisfies an undecided plan in an engaged autopilot conversation, Caracal
+  // re-evaluates the approval it deferred at plan time. A failed guardian review still leaves the
+  // plan waiting for a human decision.
   fastify.put('/zones/:zoneId/operator-conversations/:id/plans/:planSeq/secrets', async (req, reply) => {
     const params = parseParams(PlanSecretsParams, req, reply)
     if (!params) return
@@ -1757,27 +1758,44 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         throw new TxAbort(reply.code(400).send({ error: 'invalid_credentials', required }))
       }
 
-      // A decided plan is already approved or rejected; its credential window is closed.
-      const { rows: decided } = await client.query(
-        `SELECT 1 FROM operator_turns
+      const { rows: decisions } = await client.query<{ kind: string }>(
+        `SELECT kind FROM operator_turns
          WHERE conversation_id = $1 AND zone_id = $2
            AND kind IN ('approval', 'rejection')
            AND (content->>'plan_seq')::bigint = $3`,
         [params.id, params.zoneId, params.planSeq],
       )
-      if (decided[0]) throw new TxAbort(reply.code(409).send({ error: 'plan_already_decided' }))
+      const decision = decisions[0]?.kind
+      if (decision === 'rejection') throw new TxAbort(reply.code(409).send({ error: 'plan_rejected' }))
+
+      if (decision === 'approval') {
+        // Approval freezes the plan's public semantics, so accepting the same required secret
+        // fields cannot change its steps or effects. A spent plan is different: a failed step may
+        // have applied ambiguously, and an already-succeeded credential step no longer needs a
+        // replacement. Keep both closed so re-paste cannot create a second execution path.
+        const { rows: priorSteps } = await client.query<{ step_id: string; status: string }>(
+          `SELECT content->>'step_id' AS step_id, content->>'status' AS status
+           FROM operator_turns
+           WHERE conversation_id = $1 AND zone_id = $2 AND kind = 'execution'
+             AND (content->>'plan_seq')::bigint = $3`,
+          [params.id, params.zoneId, params.planSeq],
+        )
+        if (priorSteps.some((prior) => prior.status === 'failed' || (prior.status === 'succeeded' && prior.step_id === step.id))) {
+          throw new TxAbort(reply.code(409).send({ error: 'plan_already_executed' }))
+        }
+      }
 
       await storePlanStepSecrets(client, secretRef, body.step_id, body.values)
       const satisfied = await listSatisfiedPlanSteps(client, secretRef)
       const allSatisfied = content.steps.every(
         (candidate) => credentialFieldsFor(candidate.capability, candidate.args ?? {}).length === 0 || satisfied.has(candidate.id),
       )
-      return { content, allSatisfied, mode: conv[0].mode, autopilot: conv[0].autopilot === true }
+      return { content, allSatisfied, mode: conv[0].mode, autopilot: conv[0].autopilot === true, decided: decision !== undefined }
     })
 
     let autoApproved = false
     let approvalTurn: Record<string, unknown> | null = null
-    if (stored.allSatisfied && stored.mode === 'agent' && stored.autopilot && autopilotAvailable(autopilotPolicy)) {
+    if (!stored.decided && stored.allSatisfied && stored.mode === 'agent' && stored.autopilot && autopilotAvailable(autopilotPolicy)) {
       const steps = stored.content.steps.map((step) => ({ id: step.id, capability: step.capability, args: step.args ?? {} }))
       const preview = await previewPlan(fastify.db, params.zoneId, { summary: stored.content.summary, steps })
       // The same deterministic applicability gate the message path and the execute route use: the

--- a/apps/web/src/components/console/OperatorPlan.tsx
+++ b/apps/web/src/components/console/OperatorPlan.tsx
@@ -286,6 +286,7 @@ export function PlanArtifact({
 }) {
   const decide = useDecideOperatorPlan(zoneId, conversationId);
   const execute = useExecuteOperatorPlan(zoneId, conversationId);
+  const executePlan = execute.mutate;
   const busy = decide.isPending || execute.isPending;
   const decision = planDecision(plan);
   const mutatingCount = plan.steps.filter((step) => step.mutating).length;
@@ -316,24 +317,12 @@ export function PlanArtifact({
   // "runs after Connect provider" rather than the opaque step id the planner assigned.
   const stepLabels = new Map(plan.steps.map((step) => [step.id, step.summary]));
 
-  // Approve is the only gate: once a plan is approved - by the operator here or by autopilot - it
-  // is applied automatically, so there is no separate apply step. The request is armed once per
-  // plan seq; the server's execute lock makes a duplicate a no-op, and the ref keeps a re-render or
-  // the dev strict double-mount from firing it twice.
-  const requestedSeq = useRef<number | null>(null);
-  useEffect(() => {
-    if (plan.canExecute && requestedSeq.current !== plan.seq) {
-      requestedSeq.current = plan.seq;
-      execute.mutate(plan.seq);
-    }
-  }, [plan.canExecute, plan.seq, execute.mutate]);
-
   // A step that connects a credential-bearing provider collects its values through the secure
-  // prompt into the sealed vault. The plan cannot be approved - by the operator or by autopilot -
-  // until every such step is satisfied, so the prompt opens itself once when the plan arrives and
-  // stays reachable through the buttons below if it is dismissed or the values need changing.
+  // prompt into the sealed vault. Pending plans cannot be approved until every step is satisfied;
+  // approved plans keep the same secure prompt available so expired values can be replaced without
+  // changing the immutable plan or its approval.
   const credentialSteps = plan.steps.filter((step) => step.secretFields.length > 0);
-  const needsCredentials = credentialSteps.length > 0 && plan.canDecide;
+  const needsCredentials = credentialSteps.length > 0 && (plan.canDecide || plan.canExecute);
   const secretsStatus = useOperatorPlanSecrets(
     zoneId,
     conversationId,
@@ -348,8 +337,36 @@ export function PlanArtifact({
     needsCredentials && secretsStatus.data != null && unsatisfied.length === 0;
   const [promptStepId, setPromptStepId] = useState<string | null>(null);
   const promptedSeq = useRef<number | null>(null);
+  const requestedSeq = useRef<number | null>(null);
   const statusLoaded = secretsStatus.data != null;
   const firstUnsatisfiedId = unsatisfied[0]?.id ?? null;
+  const executionNeedsCredentials =
+    (execute.error as { code?: string } | null)?.code === "plan_credentials_required";
+
+  // Approve is the only authority gate. Once approved, apply automatically, but wait for the
+  // write-only vault status before dispatching a credential-bearing plan. That avoids knowingly
+  // sending an apply whose values have expired. A status-read failure still lets the server make
+  // the authoritative decision during execute.
+  useEffect(() => {
+    const credentialGateReady =
+      credentialSteps.length === 0 || credentialsReady || secretsStatus.isError;
+    if (plan.canExecute && credentialGateReady && requestedSeq.current !== plan.seq) {
+      requestedSeq.current = plan.seq;
+      executePlan(plan.seq);
+    }
+  }, [
+    credentialSteps.length,
+    credentialsReady,
+    executePlan,
+    plan.canExecute,
+    plan.seq,
+    secretsStatus.isError,
+  ]);
+
+  useEffect(() => {
+    if (executionNeedsCredentials) promptedSeq.current = null;
+  }, [executionNeedsCredentials]);
+
   useEffect(() => {
     if (!needsCredentials || !statusLoaded) return;
     if (promptedSeq.current === plan.seq) return;
@@ -365,6 +382,7 @@ export function PlanArtifact({
         onSuccess: (result) => {
           if (result.all_satisfied) {
             setPromptStepId(null);
+            if (plan.canExecute) execute.mutate(plan.seq);
             return;
           }
           const next = credentialSteps.find(
@@ -501,6 +519,26 @@ export function PlanArtifact({
             </p>
           ) : null}
         </Confirmation>
+      ) : null}
+
+      {plan.canExecute && needsCredentials && statusLoaded && !credentialsReady ? (
+        <div className="border-t border-border bg-surface px-3.5 py-2.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <KeyGlyph className="h-3.5 w-3.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+            <span className="min-w-0 flex-1 text-xs text-foreground">
+              The vaulted credentials expired or are missing. Provide the same required fields again
+              to apply this approved plan.
+            </span>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={busy || provide.isPending}
+              onClick={() => setPromptStepId((unsatisfied[0] ?? credentialSteps[0]).id)}
+            >
+              Provide credentials
+            </Button>
+          </div>
+        </div>
       ) : null}
 
       {promptStep ? (

--- a/apps/web/src/components/console/OperatorPlan.tsx
+++ b/apps/web/src/components/console/OperatorPlan.tsx
@@ -382,7 +382,13 @@ export function PlanArtifact({
         onSuccess: (result) => {
           if (result.all_satisfied) {
             setPromptStepId(null);
-            if (plan.canExecute) execute.mutate(plan.seq);
+            if (plan.canExecute) {
+              // The status invalidation triggered by the credential write may resolve before
+              // this mutation does. Mark the sequence first so that refresh cannot make the
+              // automatic effect dispatch a second apply for the same recovery.
+              requestedSeq.current = plan.seq;
+              executePlan(plan.seq);
+            }
             return;
           }
           const next = credentialSteps.find(

--- a/apps/web/src/platform/api/hooks.ts
+++ b/apps/web/src/platform/api/hooks.ts
@@ -449,7 +449,16 @@ export function useExecuteOperatorPlan(zoneId: string | null, conversationId: st
     mutationFn: (planSeq: number) =>
       consoleApi.operator.executePlan(zoneId as string, conversationId as string, planSeq),
     onSuccess: () => invalidateConversation(qc, zoneId, conversationId),
-    onError: (error) => resyncOnStalePlan(qc, zoneId, conversationId, error),
+    onError: (error, planSeq) => {
+      resyncOnStalePlan(qc, zoneId, conversationId, error);
+      // An approved plan may outlive its short-lived vaulted values. Re-read the write-only
+      // status so the plan card can reopen the secure prompt without exposing any secret.
+      if (error instanceof ConsoleApiError && error.code === "plan_credentials_required") {
+        qc.invalidateQueries({
+          queryKey: keys.operatorPlanSecrets(zoneId, conversationId, planSeq),
+        });
+      }
+    },
   });
 }
 

--- a/apps/web/src/platform/operator/view.ts
+++ b/apps/web/src/platform/operator/view.ts
@@ -171,6 +171,8 @@ export function executeErrorMessage(err: unknown): string {
       return "Nothing to apply - what this plan would create already exists in this zone.";
     case "plan_state_changed":
       return "The zone changed since this plan was approved, so applying it now would do something the approval never covered. Ask again to compose a fresh plan.";
+    case "plan_credentials_required":
+      return "The vaulted credentials expired or are missing. Provide them again to apply this approved plan.";
     case "conversation_archived":
       return "This conversation is archived, so it can't apply changes.";
     default:

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -1264,13 +1264,48 @@ describe('plan credential vault endpoints', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'step_needs_no_credentials' })
   })
 
-  it('closes the credential window once the plan is decided', async () => {
+  it('replaces expired credentials for an approved, unspent plan without changing its approval', async () => {
     const { app, clientQuery } = buildApp()
     clientQuery
       .mockResolvedValueOnce(undefined) // BEGIN
       .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: false }] }) // conv FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ content: credentialPlanContent }] }) // plan turn
-      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // already decided
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // approved
+      .mockResolvedValueOnce({ rows: [] }) // no prior execution turns
+      .mockResolvedValueOnce(undefined) // sweep expired rows
+      .mockResolvedValueOnce(undefined) // replace the sealed row
+      .mockResolvedValueOnce({ rows: [{ step_id: 's1' }] }) // all credential steps satisfied
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plans/2/secrets',
+      payload: { step_id: 's1', values: { client_id: 'anton', client_secret: 'cs_live_value' } },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body)).toEqual({
+      ok: true,
+      plan_seq: 2,
+      step_id: 's1',
+      all_satisfied: true,
+      auto_approved: false,
+      approval_turn: null,
+    })
+    expect(res.body).not.toContain('cs_live_value')
+    const insert = clientQuery.mock.calls.find((call) => String(call[0]).includes('INSERT INTO operator_plan_secrets'))
+    expect(insert).toBeDefined()
+    expect(JSON.stringify(insert![1])).not.toContain('cs_live_value')
+    // Recovery keeps the original decision; it never appends a second approval.
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_turns'))).toBe(false)
+  })
+
+  it('keeps the credential window closed for a rejected plan', async () => {
+    const { app, clientQuery } = buildApp()
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: false }] }) // conv FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ content: credentialPlanContent }] }) // plan turn
+      .mockResolvedValueOnce({ rows: [{ kind: 'rejection' }] }) // rejected
       .mockResolvedValueOnce(undefined) // ROLLBACK
     await app.ready()
     const res = await app.inject({
@@ -1279,7 +1314,28 @@ describe('plan credential vault endpoints', () => {
       payload: { step_id: 's1', values: { client_id: 'anton', client_secret: 'cs_live_value' } },
     })
     expect(res.statusCode).toBe(409)
-    expect(JSON.parse(res.body)).toEqual({ error: 'plan_already_decided' })
+    expect(JSON.parse(res.body)).toEqual({ error: 'plan_rejected' })
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_plan_secrets'))).toBe(false)
+  })
+
+  it('keeps the credential window closed after the credential step was spent', async () => {
+    const { app, clientQuery } = buildApp()
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: false }] }) // conv FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ content: credentialPlanContent }] }) // plan turn
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // approved
+      .mockResolvedValueOnce({ rows: [{ step_id: 's1', status: 'succeeded' }] }) // credential step already applied
+      .mockResolvedValueOnce(undefined) // ROLLBACK
+    await app.ready()
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plans/2/secrets',
+      payload: { step_id: 's1', values: { client_id: 'anton', client_secret: 'cs_live_value' } },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toEqual({ error: 'plan_already_executed' })
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_plan_secrets'))).toBe(false)
   })
 })
 
@@ -1418,6 +1474,47 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     })
     expect(res.statusCode).toBe(409)
     expect(JSON.parse(res.body)).toMatchObject({ error: 'plan_not_approved' })
+  })
+
+  it('asks for the exact expired credential fields before applying an approved plan', async () => {
+    const credentialPlan = {
+      summary: 'Connect Hooli OIDC',
+      steps: [
+        {
+          id: 's1',
+          capability: 'connectProvider',
+          mutating: true,
+          effect: 'create',
+          args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' },
+        },
+      ],
+    }
+    const fetchMock = controlFetch([{ id: 'provider-1' }])
+    const { app, clientQuery } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent' }] }) // conversation
+      .mockResolvedValueOnce({ rows: [{ content: credentialPlan }] }) // approved plan
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // decision
+      .mockResolvedValueOnce({ rows: [] }) // no prior execution
+      .mockResolvedValueOnce({ rows: [] }) // preview: provider name is available
+      .mockResolvedValueOnce({ rows: [] }) // vaulted credential expired
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'plan_credentials_required',
+      steps: [{ step_id: 's1', fields: ['client_id', 'client_secret'] }],
+    })
+    // The refusal happens before any governed request can spend or mutate anything.
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('refuses to execute in an ask-mode conversation', async () => {

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -1337,6 +1337,26 @@ describe('plan credential vault endpoints', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'plan_already_executed' })
     expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_plan_secrets'))).toBe(false)
   })
+
+  it('keeps the credential window closed after any execution step failed', async () => {
+    const { app, clientQuery } = buildApp()
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: false }] }) // conv FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ content: credentialPlanContent }] }) // plan turn
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // approved
+      .mockResolvedValueOnce({ rows: [{ step_id: 's2', status: 'failed' }] }) // plan is spent after an ambiguous failure
+      .mockResolvedValueOnce(undefined) // ROLLBACK
+    await app.ready()
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plans/2/secrets',
+      payload: { step_id: 's1', values: { client_id: 'anton', client_secret: 'cs_live_value' } },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toEqual({ error: 'plan_already_executed' })
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_plan_secrets'))).toBe(false)
+  })
 })
 
 describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () => {

--- a/tests/typescript/unit/web/operatorPlan.test.tsx
+++ b/tests/typescript/unit/web/operatorPlan.test.tsx
@@ -1,0 +1,113 @@
+/*
+Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+Caracal, a product of Garudex Labs
+
+This file verifies the Operator plan card dispatches credential-recovery execution exactly once.
+*/
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PlanItem } from '@/platform/operator/timeline'
+
+const state = vi.hoisted(() => ({
+  secretsProvided: false,
+  executePlan: vi.fn(),
+  provideSecrets: vi.fn(),
+}))
+
+vi.mock('@/platform/api/hooks', () => ({
+  useDecideOperatorPlan: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useExecuteOperatorPlan: () => ({
+    mutate: state.executePlan,
+    isPending: false,
+    isError: false,
+    error: null,
+    data: undefined,
+  }),
+  useOperatorCapabilities: () => ({ data: [] }),
+  useOperatorPlanSecrets: () => ({
+    data: {
+      plan_seq: 7,
+      steps: [
+        {
+          step_id: 'provider-step',
+          fields: ['client_id', 'client_secret'],
+          provided: state.secretsProvided,
+        },
+      ],
+    },
+    isError: false,
+  }),
+  useProvidePlanSecrets: () => ({
+    mutate: state.provideSecrets,
+    isPending: false,
+    isError: false,
+  }),
+}))
+
+vi.mock('@/components/console/SecretCredentialDialog', () => ({
+  SecretCredentialDialog: ({ onSubmit }: { onSubmit: (values: Record<string, string>) => void }) => (
+    <button type="button" onClick={() => onSubmit({ client_id: 'client', client_secret: 'secret' })}>
+      Submit replacement credentials
+    </button>
+  ),
+}))
+
+const { PlanArtifact } = await import('@/components/console/OperatorPlan')
+
+const plan: PlanItem = {
+  kind: 'plan',
+  id: 'plan-7',
+  seq: 7,
+  summary: 'Connect Hooli OIDC',
+  steps: [
+    {
+      id: 'provider-step',
+      capability: 'connectProvider',
+      summary: 'Connect provider',
+      mutating: true,
+      args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' },
+      status: 'pending',
+      dependsOn: [],
+      effect: 'create',
+      secretFields: ['client_id', 'client_secret'],
+    },
+  ],
+  decision: 'approved',
+  rejectionReason: null,
+  executed: false,
+  canDecide: false,
+  canExecute: true,
+  approvedByAutopilot: false,
+}
+
+afterEach(() => {
+  cleanup()
+  state.secretsProvided = false
+  state.executePlan.mockReset()
+  state.provideSecrets.mockReset()
+})
+
+describe('PlanArtifact credential recovery', () => {
+  it('does not dispatch twice when refreshed vault status resolves during recovery execution', async () => {
+    state.provideSecrets.mockImplementation((_input: unknown, options: { onSuccess: (result: { all_satisfied: boolean }) => void }) => {
+      options.onSuccess({ all_satisfied: true })
+    })
+
+    const view = render(<PlanArtifact plan={plan} zoneId="z1" conversationId="conv-1" />)
+    const submit = await screen.findByRole('button', { name: 'Submit replacement credentials' })
+    fireEvent.click(submit)
+
+    expect(state.executePlan).toHaveBeenCalledTimes(1)
+    expect(state.executePlan).toHaveBeenCalledWith(7)
+
+    // The credential mutation invalidates this status query. Model that refresh completing while
+    // the explicit execute mutation is still in flight; the automatic effect must observe that
+    // this plan sequence was already dispatched.
+    state.secretsProvided = true
+    view.rerender(<PlanArtifact plan={plan} zoneId="z1" conversationId="conv-1" />)
+
+    await waitFor(() => expect(state.executePlan).toHaveBeenCalledTimes(1))
+  })
+})

--- a/tests/typescript/unit/web/operatorView.test.ts
+++ b/tests/typescript/unit/web/operatorView.test.ts
@@ -200,6 +200,7 @@ describe('executeErrorMessage', () => {
     expect(executeErrorMessage({ code: 'plan_already_satisfied' })).toContain('already exists')
     expect(executeErrorMessage({ code: 'plan_state_changed' })).toContain('zone changed since this plan was approved')
     expect(executeErrorMessage({ code: 'plan_blocked' })).toContain("can't be applied")
+    expect(executeErrorMessage({ code: 'plan_credentials_required' })).toContain('Provide them again')
   })
   it('falls back for unknown codes', () => {
     expect(executeErrorMessage({ code: 'mystery' })).toBe("Couldn't apply the changes. Please try again.")


### PR DESCRIPTION
## Summary

- allow exact-field credential replacement for approved plans that are still safe to execute
- keep rejected plans, failed plans, and already-applied credential steps closed
- wait for vault status before automatically applying credential-bearing plans
- reopen the secure credential prompt when values expire and retry apply after replacement
- surface a specific plan_credentials_required message instead of the generic execution error

Approval remains bound to the immutable plan. Credential values stay write-only, sealed at rest, and are never returned or written to the plan ledger. Approval does not extend the vault TTL because extension only moves the same expiry window; explicit safe recovery handles both delayed execution and retained-secret retries.

## Tests

- API route tests cover expired-field reporting, approved/unspent replacement, exact field binding, redaction, rejected plans, and spent steps
- 195 focused API/web tests passed
- all 394 web unit tests passed
- full API suite: 1,438 passed, 1 skipped
- API TypeScript build passed
- web TypeScript typecheck passed
- targeted web lint passed
- git diff check passed

Closes #416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approved plans can accept replacement credentials when they expire or are missing.
  - Credential submission can automatically retry execution once all required fields are provided.
  - Users are prompted to provide credentials again when needed.

- **Bug Fixes**
  - Rejected plans and completed steps can no longer accept credential replacements.
  - Prevented already-decided plans from being approved again automatically.
  - Credential status refreshes correctly after execution failures.

- **Tests**
  - Added coverage for credential recovery, execution safeguards, and related error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->