### PR TITLE
fix(operator): bind direct plan approval to preview effects

### DIFF
--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -227,6 +227,14 @@ interface PlanTurnContent {
   review?: { status: 'reviewed' } | { status: 'review_failed'; reason?: string }
 }
 
+const PLAN_PREVIEW_EFFECTS = new Set<StepPreview['effect']>(['create', 'update', 'delete', 'exists', 'blocked', 'read_only'])
+
+function missingPlanPreviewSteps(content: PlanTurnContent): { step_id: string; capability: string }[] {
+  return content.steps
+    .filter((step) => !PLAN_PREVIEW_EFFECTS.has(step.effect as StepPreview['effect']))
+    .map((step) => ({ step_id: step.id, capability: step.capability }))
+}
+
 const ContextQuery = z.object({
   message_window: z.coerce.number().int().min(1).max(50).default(10),
 })
@@ -1569,8 +1577,6 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       return reply.code(400).send({ error: 'plan_validation_failed', validation })
     }
 
-    const contentJson = buildPlanContentJson(parsed.data.summary, validation)
-
     return withTransaction(fastify.db, async (client) => {
       const { rows: conv } = await client.query<{ status: string; mode: string; next_seq: number }>(
         `SELECT status, mode, next_seq FROM operator_conversations
@@ -1587,6 +1593,11 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       if (conv[0].mode === 'ask') {
         throw new TxAbort(reply.code(403).send({ error: 'mode_forbidden' }))
       }
+      // Direct plans pass through the same authoritative live-state preview as plans composed by
+      // the orchestrator. Persist every effect even when the preview is blocked: "previewed" means
+      // the consequence is recorded for approval, not that the plan is currently executable.
+      const preview = await previewPlan(client, params.zoneId, parsed.data)
+      const contentJson = buildPlanContentJson(parsed.data.summary, validation, undefined, undefined, preview.steps)
       const turn = await writeTurnLocked(client, {
         conversationId: params.id,
         zoneId: params.zoneId,
@@ -1596,7 +1607,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         contentJson,
         actorId: req.actor.id,
       })
-      return reply.code(201).send({ turn, validation })
+      return reply.code(201).send({ turn, validation, preview })
     })
   })
 
@@ -1648,6 +1659,13 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
 
       const secretRef = { conversationId: params.id, zoneId: params.zoneId, planSeq: body.plan_seq }
       if (kind === 'approval') {
+        // Approval is meaningful only when every persisted step carries the effect derived by the
+        // server preview. Existing effect-less plans remain rejectable, but cannot be approved
+        // under the repository's no-legacy posture; composing a fresh plan creates a bound preview.
+        const missingPreview = missingPlanPreviewSteps(planTurn[0].content)
+        if (missingPreview.length > 0) {
+          throw new TxAbort(reply.code(409).send({ error: 'plan_preview_required', steps: missingPreview }))
+        }
         // Approval is the gate that lets a change apply, so a step that collects credentials
         // through the console's secure prompt must have them in the vault before the plan can be
         // approved - by a human here or by autopilot through the paste flow. Refusing here keeps
@@ -1786,7 +1804,11 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       // plan whose create now targets something that exists rather than duplicating it.
       const governedIdentity = opts.resolveControlIdentity?.() ?? null
       const canApply = !!governedIdentity && !!opts.controlEndpoints && (await zoneGoverned(params.zoneId, governedIdentity))
-      const applicable = preview.ok && canApply && preview.steps.every((step) => step.effect !== 'exists')
+      const applicable =
+        missingPlanPreviewSteps(stored.content).length === 0 &&
+        preview.ok &&
+        canApply &&
+        preview.steps.every((step) => step.effect !== 'exists')
       const mutatingSteps = stored.content.steps.filter((step) => step.mutating === true).length
       const budget = autopilotPolicy.conversationWriteBudget
       const outcome = await approveWithAutopilot(fastify.db, {
@@ -1938,6 +1960,14 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         if (!decision[0]) return { ok: false, status: 409, body: { error: 'plan_not_approved' } }
         if (decision[0].kind === 'rejection') return { ok: false, status: 409, body: { error: 'plan_rejected' } }
 
+        // A legacy or malformed plan without a server-persisted effect was never preview-bound.
+        // Refuse before any live reads or governed calls; execution may compare only consequences
+        // that the approval actually covered.
+        const missingPreview = missingPlanPreviewSteps(planRows[0].content)
+        if (missingPreview.length > 0) {
+          return { ok: false, status: 409, body: { error: 'plan_preview_required', steps: missingPreview } }
+        }
+
         // Read every prior execution turn for this plan to decide retriability at the step
         // level. A failed step means a non-idempotent mutation may have half-applied, so the
         // whole plan is never retriable. Otherwise every recorded step succeeded, and a plan
@@ -2047,10 +2077,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         // deleted in the meantime - would apply against a world the approver never saw, so the
         // plan is refused and a fresh request composes a new plan against current state.
         const reviewedEffects = new Map(planRows[0].content.steps.map((step) => [step.id, step.effect]))
-        const drifted = remainingPreview.filter((step) => {
-          const reviewed = reviewedEffects.get(step.id)
-          return typeof reviewed === 'string' && reviewed !== step.effect
-        })
+        const drifted = remainingPreview.filter((step) => reviewedEffects.get(step.id) !== step.effect)
         if (drifted.length > 0) {
           return {
             ok: false,

--- a/apps/web/src/platform/api/client.ts
+++ b/apps/web/src/platform/api/client.ts
@@ -97,6 +97,7 @@ import type {
   OperatorNarrativeInput,
   OperatorPlanDecisionInput,
   OperatorPlanInput,
+  OperatorPlanPreview,
   OperatorPlanSecretsResult,
   OperatorPlanSecretsStatus,
   OperatorPlanValidation,
@@ -1177,7 +1178,11 @@ export const consoleApi = {
         { method: "POST", body: JSON.stringify(plan) },
       ),
     createPlan: (zoneId: string, conversationId: string, plan: OperatorPlanInput) =>
-      request<{ turn: OperatorTurn; validation: OperatorPlanValidation }>(
+      request<{
+        turn: OperatorTurn;
+        validation: OperatorPlanValidation;
+        preview: OperatorPlanPreview;
+      }>(
         `/v1/zones/${encodeURIComponent(zoneId)}/operator-conversations/${encodeURIComponent(
           conversationId,
         )}/plan`,

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -976,6 +976,21 @@ export interface OperatorPlanValidation {
   diagnostics: OperatorPlanDiagnostic[];
 }
 
+export type OperatorStepEffect =
+  "create" | "update" | "delete" | "exists" | "blocked" | "read_only";
+
+export interface OperatorPlanPreviewStep extends OperatorValidatedStep {
+  effect: OperatorStepEffect;
+  detail: string;
+}
+
+export interface OperatorPlanPreview {
+  ok: boolean;
+  mutating: boolean;
+  steps: OperatorPlanPreviewStep[];
+  diagnostics: OperatorPlanDiagnostic[];
+}
+
 export type OperatorConversationStatus = "active" | "archived";
 
 // The operation mode of a conversation, a Caracal-side setting enforced by the API. agent allows
@@ -1287,7 +1302,7 @@ export type OperatorMessageResult = (
       ok: true;
       turn: OperatorTurn;
       validation: OperatorPlanValidation;
-      preview: { ok: boolean; mutating: boolean; steps: OperatorValidatedStep[] };
+      preview: OperatorPlanPreview;
       // Present only for a composed (compound) plan; absent for a single change.
       advisory?: OperatorSecurityAdvisory;
       // Whether Caracal-governed autopilot auto-satisfied this plan's approval, and the approval

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -979,7 +979,11 @@ export interface OperatorPlanValidation {
 export type OperatorStepEffect =
   "create" | "update" | "delete" | "exists" | "blocked" | "read_only";
 
-export interface OperatorPlanPreviewStep extends OperatorValidatedStep {
+export interface OperatorPlanPreviewStep {
+  id: string;
+  capability: string;
+  title: string;
+  mutating: boolean;
   effect: OperatorStepEffect;
   detail: string;
 }

--- a/apps/web/src/platform/operator/view.ts
+++ b/apps/web/src/platform/operator/view.ts
@@ -171,6 +171,8 @@ export function executeErrorMessage(err: unknown): string {
       return "Nothing to apply - what this plan would create already exists in this zone.";
     case "plan_state_changed":
       return "The zone changed since this plan was approved, so applying it now would do something the approval never covered. Ask again to compose a fresh plan.";
+    case "plan_preview_required":
+      return "This plan has no server-verified effects preview, so it can't be applied. Ask again to compose a fresh plan.";
     case "conversation_archived":
       return "This conversation is archived, so it can't apply changes.";
     default:
@@ -188,6 +190,8 @@ export function decideErrorMessage(err: unknown): string {
       return "This plan was already decided. The latest state is shown above.";
     case "plan_not_found":
       return "This plan is no longer available.";
+    case "plan_preview_required":
+      return "This plan has no server-verified effects preview and can't be approved. Compose a fresh plan or reject it.";
     case "mode_forbidden":
       return "This conversation is in ask mode, so plans can't be approved here.";
     case "conversation_archived":

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -751,6 +751,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan', () => {
     clientQuery
       .mockResolvedValueOnce(undefined) // BEGIN
       .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 2 }] }) // SELECT ... FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // authoritative preview: provider name is available
       .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE next_seq
       .mockResolvedValueOnce({ rows: [planRow] }) // INSERT turn
       .mockResolvedValueOnce(undefined) // COMMIT
@@ -764,10 +765,51 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan', () => {
     const body = JSON.parse(res.body)
     expect(body.turn).toMatchObject({ kind: 'plan', seq: 2 })
     expect(body.validation).toMatchObject({ ok: true, mutating: true })
-    // The persisted content carries the resolved title and authoritative mutating flag.
-    const insert = clientQuery.mock.calls[3]
+    expect(body.preview.steps[0]).toMatchObject({ id: 's1', effect: 'create' })
+    // The persisted content carries the resolved title, authoritative mutating flag, and the
+    // server-derived live-state effect the approval will cover.
+    const insert = clientQuery.mock.calls[4]
     const persisted = JSON.parse(insert[1][6])
-    expect(persisted.steps[0]).toMatchObject({ id: 's1', capability: 'connectProvider', mutating: true })
+    expect(persisted.steps[0]).toMatchObject({ id: 's1', capability: 'connectProvider', mutating: true, effect: 'create' })
+  })
+
+  it('persists a blocked effect rather than treating preview.ok as the approval boundary', async () => {
+    const { app, clientQuery } = buildApp()
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', next_seq: 2 }] }) // conversation
+      .mockResolvedValueOnce({ rows: [] }) // application is not live, so the preview is blocked
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE next_seq
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'turn-2',
+            conversation_id: 'conv-1',
+            seq: 2,
+            role: 'operator',
+            kind: 'plan',
+            content: {},
+            actor_id: 'actor-1',
+            created_at: '2026-01-01T00:00:02Z',
+          },
+        ],
+      }) // INSERT turn
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan',
+      payload: {
+        summary: 'Rotate missing app',
+        steps: [{ id: 's1', capability: 'rotateApplicationSecret', args: { application_id: 'app-missing' } }],
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(JSON.parse(res.body).preview).toMatchObject({ ok: false, steps: [{ id: 's1', effect: 'blocked' }] })
+    const insert = clientQuery.mock.calls.find((call) => String(call[0]).includes('INSERT INTO operator_turns'))
+    expect(JSON.parse(String(insert?.[1]?.[6])).steps[0]).toMatchObject({ id: 's1', effect: 'blocked' })
   })
 
   it('returns 404 when the conversation is absent', async () => {
@@ -824,7 +866,14 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/decision', () =
       .mockResolvedValueOnce(undefined) // BEGIN
       .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 3 }] }) // SELECT ... FOR UPDATE
       .mockResolvedValueOnce({
-        rows: [{ content: { summary: 'Register app', steps: [{ id: 's1', capability: 'registerApplication', args: { name: 'Fiona' } }] } }],
+        rows: [
+          {
+            content: {
+              summary: 'Register app',
+              steps: [{ id: 's1', capability: 'registerApplication', effect: 'create', args: { name: 'Fiona' } }],
+            },
+          },
+        ],
       }) // plan turn exists
       .mockResolvedValueOnce({ rows: [] }) // not already decided
       .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE next_seq
@@ -859,7 +908,14 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/decision', () =
       .mockResolvedValueOnce(undefined) // BEGIN
       .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 3 }] }) // SELECT ... FOR UPDATE
       .mockResolvedValueOnce({
-        rows: [{ content: { summary: 'Register app', steps: [{ id: 's1', capability: 'registerApplication', args: { name: 'Fiona' } }] } }],
+        rows: [
+          {
+            content: {
+              summary: 'Register app',
+              steps: [{ id: 's1', capability: 'registerApplication', effect: 'create', args: { name: 'Fiona' } }],
+            },
+          },
+        ],
       }) // plan turn exists
       .mockResolvedValueOnce({ rows: [] }) // not already decided
       .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE next_seq
@@ -910,6 +966,39 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/decision', () =
     expect(JSON.parse(res.body)).toMatchObject({ error: 'plan_already_decided' })
   })
 
+  it('refuses to approve a legacy plan without persisted preview effects', async () => {
+    const { app, clientQuery } = buildApp()
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', next_seq: 3 }] }) // conversation
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            content: {
+              summary: 'Register app',
+              steps: [{ id: 's1', capability: 'registerApplication', args: { name: 'Fiona' } }],
+            },
+          },
+        ],
+      }) // effect-less plan
+      .mockResolvedValueOnce({ rows: [] }) // not already decided
+      .mockResolvedValueOnce(undefined) // ROLLBACK
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/decision',
+      payload: { plan_seq: 2, decision: 'approved' },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'plan_preview_required',
+      steps: [{ step_id: 's1', capability: 'registerApplication' }],
+    })
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_turns'))).toBe(false)
+  })
+
   it('rejects an invalid decision body', async () => {
     const { app } = buildApp()
     await app.ready()
@@ -954,7 +1043,14 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/decision', () =
           {
             content: {
               summary: 'Connect Hooli OIDC',
-              steps: [{ id: 's1', capability: 'connectProvider', args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' } }],
+              steps: [
+                {
+                  id: 's1',
+                  capability: 'connectProvider',
+                  effect: 'create',
+                  args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' },
+                },
+              ],
             },
           },
         ],
@@ -1022,11 +1118,18 @@ describe('plan credential vault endpoints', () => {
     summary: 'Connect Hooli OIDC',
     review: { status: 'reviewed' as const },
     steps: [
-      { id: 's1', capability: 'connectProvider', mutating: true, args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' } },
+      {
+        id: 's1',
+        capability: 'connectProvider',
+        mutating: true,
+        effect: 'create',
+        args: { name: 'Hooli OIDC', kind: 'oauth2_client_credentials' },
+      },
       {
         id: 's2',
         capability: 'defineResource',
         mutating: true,
+        effect: 'create',
         args: {
           name: 'PiperNet',
           scopes: ['mesh.read'],
@@ -1199,6 +1302,37 @@ describe('plan credential vault endpoints', () => {
     ).toBe(false)
   })
 
+  it('does not auto-approve a reviewed legacy plan without persisted preview effects', async () => {
+    const content = {
+      ...credentialPlanContent,
+      steps: credentialPlanContent.steps.map(({ effect: _effect, ...step }) => step),
+    }
+    const { app, db, clientQuery } = buildApp(true, { autopilotPolicy: buildAutopilotPolicy({ enabled: true }), ...governedControl })
+    db.query.mockImplementation(async (sql: string) => (String(sql).includes('WHERE id = $1') ? { rows: [{ one: 1 }] } : { rows: [] }))
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN credential write
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: true }] })
+      .mockResolvedValueOnce({ rows: [{ content }] })
+      .mockResolvedValueOnce({ rows: [] }) // undecided
+      .mockResolvedValueOnce(undefined) // sweep expired rows
+      .mockResolvedValueOnce(undefined) // INSERT sealed row
+      .mockResolvedValueOnce({ rows: [{ step_id: 's1' }] }) // credential requirement satisfied
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plans/2/secrets',
+      payload: { step_id: 's1', values: { client_id: 'anton', client_secret: 'cs_live_value' } },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body)).toMatchObject({ ok: true, all_satisfied: true, auto_approved: false, approval_turn: null })
+    expect(
+      clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_turns') && String(call[1]?.[5]) === 'approval'),
+    ).toBe(false)
+  })
+
   it('does not race a human decision while completing deferred autopilot approval', async () => {
     const { app, db, clientQuery } = buildApp(true, { autopilotPolicy: buildAutopilotPolicy({ enabled: true }), ...governedControl })
     db.query.mockImplementation(async (sql: string) => (String(sql).includes('WHERE id = $1') ? { rows: [{ one: 1 }] } : { rows: [] }))
@@ -1291,6 +1425,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
         id: 's1',
         capability: 'grantAccess',
         mutating: true,
+        effect: 'create',
         args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-1', scopes: ['invoices.read'] },
       },
     ],
@@ -1420,6 +1555,42 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     expect(JSON.parse(res.body)).toMatchObject({ error: 'plan_not_approved' })
   })
 
+  it('refuses to execute an approved legacy plan without persisted preview effects', async () => {
+    const fetchMock = controlFetch([])
+    const { app, clientQuery } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    const legacyPlan = {
+      summary: 'Grant access',
+      steps: [
+        {
+          id: 's1',
+          capability: 'grantAccess',
+          mutating: true,
+          args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-1', scopes: ['invoices.read'] },
+        },
+      ],
+    }
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent' }] }) // conversation
+      .mockResolvedValueOnce({ rows: [{ content: legacyPlan }] }) // effect-less plan
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // legacy approval
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'plan_preview_required',
+      steps: [{ step_id: 's1', capability: 'grantAccess' }],
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('refuses to execute in an ask-mode conversation', async () => {
     // The apply step is refused in ask mode before the plan or its approval is even resolved, so
     // an ask conversation has no reachable path to apply a change even if one were approved.
@@ -1492,11 +1663,12 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     const resumePlan = {
       summary: 'Set up billing',
       steps: [
-        { id: 's1', capability: 'registerApplication', mutating: true, args: { name: 'Billing' } },
+        { id: 's1', capability: 'registerApplication', mutating: true, effect: 'create', args: { name: 'Billing' } },
         {
           id: 's2',
           capability: 'grantAccess',
           mutating: true,
+          effect: 'create',
           args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-1', scopes: ['invoices.read'] },
         },
       ],
@@ -1559,6 +1731,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
           id: 's1',
           capability: 'grantAccess',
           mutating: true,
+          effect: 'create',
           args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-1', scopes: ['invoices:read'] },
         },
       ],
@@ -1791,7 +1964,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     const { app, clientQuery } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
     const registerPlan = {
       summary: 'Register',
-      steps: [{ id: 's1', capability: 'registerApplication', mutating: true, args: { name: 'Billing' } }],
+      steps: [{ id: 's1', capability: 'registerApplication', mutating: true, effect: 'create', args: { name: 'Billing' } }],
     }
     clientQuery
       .mockResolvedValueOnce(undefined) // BEGIN
@@ -1964,7 +2137,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     }
     const registerPlan = {
       summary: 'Register the Billing application',
-      steps: [{ id: 's1', capability: 'registerApplication', mutating: true, args: { name: 'Billing' } }],
+      steps: [{ id: 's1', capability: 'registerApplication', mutating: true, effect: 'create', args: { name: 'Billing' } }],
     }
     const verdict = { status: 'matched', summary: 'The Billing application is present in current state.', findings: [] }
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/tests/typescript/unit/web/client.test.ts
+++ b/tests/typescript/unit/web/client.test.ts
@@ -375,7 +375,7 @@ describe('operator conversation lifecycle', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('creates a plan and returns the persisted turn and validation', async () => {
+  it('creates a plan and returns the persisted turn, validation, and authoritative preview', async () => {
     const body = {
       turn: {
         id: 'turn-2',
@@ -388,6 +388,21 @@ describe('operator conversation lifecycle', () => {
         created_at: '2026-01-01T00:00:02Z',
       },
       validation: { ok: true, mutating: true, mutating_step_count: 1, steps: [], diagnostics: [] },
+      preview: {
+        ok: true,
+        mutating: true,
+        diagnostics: [],
+        steps: [
+          {
+            id: 's1',
+            capability: 'connectProvider',
+            title: 'Connect provider',
+            mutating: true,
+            effect: 'create',
+            detail: "Creates provider 'GitHub'.",
+          },
+        ],
+      },
     }
     const fetchMock = vi.fn(async () => jsonResponse(201, body))
     globalThis.fetch = fetchMock as unknown as typeof fetch

--- a/tests/typescript/unit/web/operatorView.test.ts
+++ b/tests/typescript/unit/web/operatorView.test.ts
@@ -200,6 +200,7 @@ describe('executeErrorMessage', () => {
     expect(executeErrorMessage({ code: 'plan_already_satisfied' })).toContain('already exists')
     expect(executeErrorMessage({ code: 'plan_state_changed' })).toContain('zone changed since this plan was approved')
     expect(executeErrorMessage({ code: 'plan_blocked' })).toContain("can't be applied")
+    expect(executeErrorMessage({ code: 'plan_preview_required' })).toContain('server-verified effects preview')
   })
   it('falls back for unknown codes', () => {
     expect(executeErrorMessage({ code: 'mystery' })).toBe("Couldn't apply the changes. Please try again.")
@@ -211,6 +212,7 @@ describe('decideErrorMessage', () => {
   it('names known decision failures', () => {
     expect(decideErrorMessage({ code: 'plan_already_decided' })).toContain('already decided')
     expect(decideErrorMessage({ code: 'plan_not_found' })).toBe('This plan is no longer available.')
+    expect(decideErrorMessage({ code: 'plan_preview_required' })).toContain("can't be approved")
   })
   it('falls back for unknown codes', () => {
     expect(decideErrorMessage({ code: 'mystery' })).toBe("Couldn't record the decision. Please try again.")


### PR DESCRIPTION
## Summary

- preview direct plans against authoritative live state before persistence and store each per-step effect
- refuse human or deferred-autopilot approval for effect-less legacy plans, while keeping rejection available
- fail closed at execution when approved effects are missing and always compare the fresh preview with the approved effects
- expose the direct-plan preview in the typed web client and surface actionable approval/execution errors
- add regression coverage for blocked previews, legacy plans, deferred autopilot, execute preflight, and state drift

## Verification

- `CI=true pnpm --filter @caracalai/api build`
- `CI=true pnpm --filter @caracalai/web typecheck`
- `CI=true pnpm --filter @caracalai/web lint` (0 errors; existing repository warnings only)
- `CI=true pnpm --filter @caracalai/api test` (1,439 passed; 1 skipped)
- `CI=true pnpm exec vitest run tests/typescript/unit/web` (394 passed)
- issue-focused API/client/view suite repeated 10 times (224 passed per run)
- `git diff --check`

Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan creation now returns a detailed preview showing each step’s expected effect and details.
  * Preview information is retained for approvals, automated actions, and execution.
* **Bug Fixes**
  * Plans without valid previews are blocked from approval, automation, or execution.
  * Improved detection of differences between reviewed and executed plan effects.
  * Added clearer messages when a required preview is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->