### PR TITLE
fix(operator): make provider reconciliation durable

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -396,6 +396,9 @@ export async function buildApp({ cfg, db, redis, isDraining }: AppDeps) {
           onRegistryChange: (configs) => {
             storeConfigs = configs
           },
+          onProviderUnavailable: (slug) => {
+            storeConfigs = storeConfigs.filter((config) => config.id !== slug && !config.id.startsWith(`${slug}__`))
+          },
         })
       : null
 
@@ -473,13 +476,31 @@ export async function buildApp({ cfg, db, redis, isDraining }: AppDeps) {
         // store-managed providers (already sealed in a prior run, reconciled by identifier
         // without a key), so a restart never archives a console-added provider.
         const storeRecords = await listAiProviders(db)
-        const storeUpstreams: GovernedUpstream[] = storeRecords.map((record) => ({
-          id: record.slug,
-          baseUrl: record.baseUrl,
-          auth: record.auth,
-        }))
-        const desiredUpstreams = [...envGovernedUpstreams, ...storeUpstreams]
-        const identity = await provisionSystemZone(admin, audience, findZoneBySlug, roles, desiredUpstreams)
+        const storeUpstreams: GovernedUpstream[] = storeRecords
+          .filter(
+            (record) =>
+              (record.reconciliationState === 'ready' && record.reconciledAt !== null) ||
+              (record.reconciliationState !== 'ready' && record.reconciliationState !== 'deleting' && !record.credentialRequired),
+          )
+          .map((record) => ({
+            id: record.slug,
+            baseUrl: record.baseUrl,
+            auth: record.auth,
+          }))
+        const preservedStoreSlugs = storeRecords
+          .filter(
+            (record) =>
+              record.reconciliationState !== 'deleting' &&
+              ((record.reconciliationState === 'ready' && record.reconciledAt === null) ||
+                (record.reconciliationState !== 'ready' && record.credentialRequired)),
+          )
+          .map((record) => record.slug)
+        const preservedStoreSlugSet = new Set(preservedStoreSlugs)
+        // A store row waiting for verification or a replacement key must also shadow an env
+        // upstream with the same slug. Otherwise boot would reconcile the env entry first and
+        // mutate the very sealed object this path is required to preserve untouched.
+        const desiredUpstreams = [...envGovernedUpstreams.filter((upstream) => !preservedStoreSlugSet.has(upstream.id)), ...storeUpstreams]
+        const identity = await provisionSystemZone(admin, audience, findZoneBySlug, roles, desiredUpstreams, preservedStoreSlugs)
         operatorControlIdentity.current = {
           zoneId: identity.zoneId,
           llm: identity.llm,
@@ -491,6 +512,10 @@ export async function buildApp({ cfg, db, redis, isDraining }: AppDeps) {
         // map, so a console-added provider is live immediately after a restart.
         const resourceBySlug = new Map(identity.governedResources.map((entry) => [entry.id, entry.resourceIdentifier]))
         if (governedFetch) storeConfigs = buildStoreProviderConfigs(storeRecords, resourceBySlug, cfg.gatewayUrl, governedFetch)
+        // Complete restart-safe metadata-only updates and delete tombstones now that the fresh
+        // Operator identity is available. Credential-dependent failures stay explicit and inert
+        // until an operator retries with the plaintext key, which is never persisted.
+        await aiManager?.recover()
         if (isolatedSystemZone.has(identity.zoneId)) {
           // The Operator must govern its own system zone; listing it as an isolated zone
           // would block self-governance before the identity check. Warn rather than fail so

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -515,7 +515,16 @@ export async function buildApp({ cfg, db, redis, isDraining }: AppDeps) {
         // Complete restart-safe metadata-only updates and delete tombstones now that the fresh
         // Operator identity is available. Credential-dependent failures stay explicit and inert
         // until an operator retries with the plaintext key, which is never persisted.
-        await aiManager?.recover()
+        try {
+          await aiManager?.recover()
+        } catch (err) {
+          // Provisioning already succeeded and the identity is live. Recovery is best effort and
+          // retries on the next rotation tick, so report it separately without suppressing the
+          // successful provisioning record below.
+          provisionLog.error('operator provider reconciliation recovery failed', {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
         if (isolatedSystemZone.has(identity.zoneId)) {
           // The Operator must govern its own system zone; listing it as an isolated zone
           // would block self-governance before the identity check. Warn rather than fail so

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,7 +34,7 @@ import { buildOperatorAuthority } from './operator-authority.js'
 import { researcherRoleScopes, executorRoleScopes } from './operator-agent-roles.js'
 import { isReservedZone } from './reserved-namespace.js'
 import type { ProviderConfig } from './operator-gateway.js'
-import { createOperatorAiManager, buildStoreProviderConfigs, type OperatorAiManager } from './operator-ai-manager.js'
+import { createOperatorAiManager, buildStoreProviderConfigs, planStoreUpstreams, type OperatorAiManager } from './operator-ai-manager.js'
 import { listAiProviders } from './operator-ai-store.js'
 import type { OperatorControlIdentity } from './config.js'
 import { getTraceContext, parseTraceparent, bindTrace, buildPinoRedactPaths, CaracalError, createLogger } from '@caracalai/core'
@@ -474,33 +474,12 @@ export async function buildApp({ cfg, db, redis, isDraining }: AppDeps) {
         await lock.query('SELECT pg_advisory_lock($1)', [SYSTEM_ZONE_PROVISION_LOCK])
         // The desired set is the env upstreams (re-sealed from their keys) plus the
         // store-managed providers (already sealed in a prior run, reconciled by identifier
-        // without a key), so a restart never archives a console-added provider.
+        // without a key), so a restart never archives a console-added provider. Boot classifies
+        // the rows exactly as recovery does, so provisioning and the reconcile that follows it
+        // always agree on which rows may be routed and which must only be preserved.
         const storeRecords = await listAiProviders(db)
-        const storeUpstreams: GovernedUpstream[] = storeRecords
-          .filter(
-            (record) =>
-              (record.reconciliationState === 'ready' && record.reconciledAt !== null) ||
-              (record.reconciliationState !== 'ready' && record.reconciliationState !== 'deleting' && !record.credentialRequired),
-          )
-          .map((record) => ({
-            id: record.slug,
-            baseUrl: record.baseUrl,
-            auth: record.auth,
-          }))
-        const preservedStoreSlugs = storeRecords
-          .filter(
-            (record) =>
-              record.reconciliationState !== 'deleting' &&
-              ((record.reconciliationState === 'ready' && record.reconciledAt === null) ||
-                (record.reconciliationState !== 'ready' && record.credentialRequired)),
-          )
-          .map((record) => record.slug)
-        const preservedStoreSlugSet = new Set(preservedStoreSlugs)
-        // A store row waiting for verification or a replacement key must also shadow an env
-        // upstream with the same slug. Otherwise boot would reconcile the env entry first and
-        // mutate the very sealed object this path is required to preserve untouched.
-        const desiredUpstreams = [...envGovernedUpstreams.filter((upstream) => !preservedStoreSlugSet.has(upstream.id)), ...storeUpstreams]
-        const identity = await provisionSystemZone(admin, audience, findZoneBySlug, roles, desiredUpstreams, preservedStoreSlugs)
+        const plan = planStoreUpstreams(envGovernedUpstreams, storeRecords, { recover: true })
+        const identity = await provisionSystemZone(admin, audience, findZoneBySlug, roles, plan.upstreams, plan.preservedSlugs)
         operatorControlIdentity.current = {
           zoneId: identity.zoneId,
           llm: identity.llm,

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -7,11 +7,12 @@ import type { AdminClient } from '@caracalai/admin'
 import type { Queryable } from './db.js'
 import type { OperatorControlIdentity } from './config.js'
 import type { ProviderConfig } from './operator-gateway.js'
-import { GovernedUpstream, provisionGovernedUpstreams } from './system-zone.js'
+import { GovernedUpstream, llmProviderIdentifier, llmResourceIdentifier, provisionGovernedUpstreams } from './system-zone.js'
 import {
   deleteAiProvider,
   getAiProvider,
   listAiProviders,
+  setAiProviderReconciliation,
   upsertAiProvider,
   type AuthPlacement,
   type OperatorAiProviderRecord,
@@ -29,9 +30,16 @@ export interface OperatorAiProviderView {
   contextWindow: number
   enabled: boolean
   auth: AuthPlacement
+  reconciliationState: OperatorAiProviderRecord['reconciliationState']
+  reconciliationErrorCode: string | null
+  credentialRequired: boolean
+  reconciledAt: string | null
 }
 
 function toView(record: OperatorAiProviderRecord): OperatorAiProviderView {
+  // Rows migrated from the pre-reconciliation schema have no proof that their metadata matches
+  // the sealed resource. Present them as pending until restart recovery verifies that invariant.
+  const reconciliationState = record.reconciliationState === 'ready' && !record.reconciledAt ? 'pending' : record.reconciliationState
   return {
     slug: record.slug,
     label: record.label,
@@ -40,6 +48,10 @@ function toView(record: OperatorAiProviderRecord): OperatorAiProviderView {
     contextWindow: record.contextWindow,
     enabled: record.enabled,
     auth: record.auth,
+    reconciliationState,
+    reconciliationErrorCode: record.reconciliationErrorCode,
+    credentialRequired: record.credentialRequired,
+    reconciledAt: record.reconciledAt,
   }
 }
 
@@ -120,6 +132,7 @@ export function buildStoreProviderConfigs(
 ): ProviderConfig[] {
   const configs: ProviderConfig[] = []
   for (const record of records) {
+    if (record.reconciliationState !== 'ready' || !record.reconciledAt) continue
     if (!record.enabled) continue
     const resourceIdentifier = resourceBySlug.get(record.slug)
     if (!resourceIdentifier) continue
@@ -166,6 +179,7 @@ export interface OperatorAiManager {
   update(slug: string, patch: UpdateProviderInput): Promise<OperatorAiProviderView>
   rotateKey(slug: string, apiKey: string): Promise<void>
   remove(slug: string): Promise<boolean>
+  recover(): Promise<void>
 }
 
 export interface OperatorAiManagerDeps {
@@ -183,6 +197,9 @@ export interface OperatorAiManagerDeps {
   // Publishes the rebuilt store-provider gateway entries so the next request's gateway includes
   // the change without an env edit or restart.
   onRegistryChange: (configs: ProviderConfig[]) => void
+  // Removes a provider from the live gateway before its sealed resource is touched. A failed or
+  // partial reconcile therefore fails closed instead of leaving stale runtime routing enabled.
+  onProviderUnavailable: (slug: string) => void
 }
 
 // Creates the manager that owns the runtime lifecycle of governed model providers. Every write
@@ -190,14 +207,87 @@ export interface OperatorAiManagerDeps {
 // then republishes the gateway registry, so the live Operator and the sealed grants stay in
 // lockstep with the store.
 export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAiManager {
-  async function reconcile(keyOverride?: { slug: string; apiKey: string }): Promise<void> {
+  const RECONCILIATION_FAILED = 'reconciliation_failed'
+
+  async function reconcile(options: {
+    targetSlug?: string
+    keyOverride?: { slug: string; apiKey: string }
+    recover?: boolean
+  }): Promise<{ id: string; resourceIdentifier: string }[]> {
     const identity = deps.resolveIdentity()
     if (!identity) throw new OperatorAiUnavailableError()
     const records = await listAiProviders(deps.db)
-    const upstreams = mergeDesiredUpstreams(deps.envUpstreams, records, keyOverride)
-    const governed = await provisionGovernedUpstreams(deps.admin, identity.zoneId, identity.llm.applicationId, upstreams)
+    const selected = records.filter((record) => {
+      if (record.reconciliationState === 'deleting') return false
+      if (record.reconciliationState === 'ready') return record.reconciledAt !== null
+      if (record.slug === options.targetSlug) return true
+      return options.recover === true && !record.credentialRequired
+    })
+    const selectedSlugs = new Set(selected.map((record) => record.slug))
+    // A row waiting for a credential cannot be replayed after restart because plaintext keys are
+    // intentionally never stored. Retain any already-sealed provider while revoking its grant;
+    // the operator must retry the mutation with the key to make it ready again.
+    const preservedSlugs = records
+      .filter((record) => record.reconciliationState !== 'deleting' && !selectedSlugs.has(record.slug))
+      .map((record) => record.slug)
+    const upstreams = mergeDesiredUpstreams(deps.envUpstreams, selected, options.keyOverride)
+    return provisionGovernedUpstreams(deps.admin, identity.zoneId, identity.llm.applicationId, upstreams, preservedSlugs)
+  }
+
+  async function publish(governed: { id: string; resourceIdentifier: string }[]): Promise<void> {
+    const records = await listAiProviders(deps.db)
     const resourceBySlug = new Map(governed.map((entry) => [entry.id, entry.resourceIdentifier]))
     deps.onRegistryChange(buildStoreProviderConfigs(records, resourceBySlug, deps.gatewayUrl, deps.governedFetch))
+  }
+
+  async function markFailure(slug: string, state: 'error' | 'deleting', credentialRequired: boolean): Promise<void> {
+    await setAiProviderReconciliation(deps.db, slug, state, RECONCILIATION_FAILED, credentialRequired).catch(() => {})
+  }
+
+  async function failClosed(slug: string, state: 'error' | 'deleting', credentialRequired: boolean): Promise<void> {
+    await markFailure(slug, state, credentialRequired)
+    // Reconcile once more without selecting the failed target. This best-effort pass revokes any
+    // grant that may have been installed before a later step failed, while retaining a sealed
+    // credential only when the durable row needs it for an explicit retry.
+    try {
+      const governed = await reconcile({})
+      await publish(governed)
+    } catch {
+      // The durable non-ready state and the pre-reconcile registry removal remain the backstop;
+      // startup recovery will retry cleanup after a process or control-plane outage.
+    }
+  }
+
+  async function quarantineUnsafeUnverified(records: OperatorAiProviderRecord[]): Promise<void> {
+    const identity = deps.resolveIdentity()
+    if (!identity) throw new OperatorAiUnavailableError()
+    const unverified = records.filter((record) => record.reconciliationState === 'ready' && !record.reconciledAt)
+    if (unverified.length === 0) return
+
+    const [providers, resources] = await Promise.all([
+      deps.admin.providers.list(identity.zoneId),
+      deps.admin.resources.list(identity.zoneId),
+    ])
+    const providerIdentifiers = new Set(providers.map((provider) => provider.identifier))
+    const resourcesByIdentifier = new Map(resources.map((resource) => [resource.identifier, resource]))
+
+    for (const record of unverified) {
+      const providerExists = providerIdentifiers.has(llmProviderIdentifier(record.slug))
+      const resource = resourcesByIdentifier.get(llmResourceIdentifier(record.slug))
+      // A missing provider cannot be recreated without plaintext key material. A resource that
+      // still names another endpoint is evidence of a pre-migration partial update; repointing it
+      // would send the old sealed credential to the new host. Both cases require an explicit key.
+      if (!providerExists || (resource && resource.upstream_url !== record.baseUrl)) {
+        await setAiProviderReconciliation(deps.db, record.slug, 'error', RECONCILIATION_FAILED, true)
+        deps.onProviderUnavailable(record.slug)
+      } else {
+        // Make verification progress durable before the control-plane write. If recovery fails
+        // after this point, ordinary lifecycle operations still cannot select this row; only a
+        // later recovery pass may finish it and stamp reconciled_at.
+        await setAiProviderReconciliation(deps.db, record.slug, 'pending', null, false)
+        deps.onProviderUnavailable(record.slug)
+      }
+    }
   }
 
   return {
@@ -212,7 +302,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
 
     async create(input) {
       if (!this.available()) throw new OperatorAiUnavailableError()
-      const record = await upsertAiProvider(deps.db, {
+      await upsertAiProvider(deps.db, {
         slug: input.slug,
         label: input.label,
         baseUrl: input.baseUrl,
@@ -220,9 +310,21 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
         contextWindow: input.contextWindow,
         enabled: input.enabled,
         auth: input.auth,
+        reconciliationState: 'pending',
+        reconciliationErrorCode: null,
+        credentialRequired: true,
       })
-      await reconcile({ slug: input.slug, apiKey: input.apiKey })
-      return toView(record)
+      deps.onProviderUnavailable(input.slug)
+      try {
+        const governed = await reconcile({ targetSlug: input.slug, keyOverride: { slug: input.slug, apiKey: input.apiKey } })
+        const record = await setAiProviderReconciliation(deps.db, input.slug, 'ready', null, false)
+        if (!record) throw new OperatorAiNotFoundError(input.slug)
+        await publish(governed)
+        return toView(record)
+      } catch (err) {
+        await failClosed(input.slug, 'error', true)
+        throw err
+      }
     },
 
     async update(slug, patch) {
@@ -231,8 +333,9 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
       if (!existing) throw new OperatorAiNotFoundError(slug)
       const baseUrl = patch.baseUrl ?? existing.baseUrl
       const endpointMoved = baseUrl !== existing.baseUrl
-      if (endpointMoved && !patch.apiKey) throw new OperatorAiKeyRequiredError(slug)
-      const record = await upsertAiProvider(deps.db, {
+      if ((endpointMoved || existing.credentialRequired) && !patch.apiKey) throw new OperatorAiKeyRequiredError(slug)
+      const credentialRequired = endpointMoved || existing.credentialRequired || patch.apiKey !== undefined
+      await upsertAiProvider(deps.db, {
         slug,
         label: patch.label ?? existing.label,
         baseUrl,
@@ -240,23 +343,83 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
         contextWindow: patch.contextWindow ?? existing.contextWindow,
         enabled: patch.enabled ?? existing.enabled,
         auth: patch.auth ?? existing.auth,
+        reconciliationState: 'pending',
+        reconciliationErrorCode: null,
+        credentialRequired,
       })
-      await reconcile(patch.apiKey ? { slug, apiKey: patch.apiKey } : undefined)
-      return toView(record)
+      deps.onProviderUnavailable(slug)
+      try {
+        const governed = await reconcile({
+          targetSlug: slug,
+          keyOverride: patch.apiKey ? { slug, apiKey: patch.apiKey } : undefined,
+        })
+        const record = await setAiProviderReconciliation(deps.db, slug, 'ready', null, false)
+        if (!record) throw new OperatorAiNotFoundError(slug)
+        await publish(governed)
+        return toView(record)
+      } catch (err) {
+        await failClosed(slug, 'error', credentialRequired)
+        throw err
+      }
     },
 
     async rotateKey(slug, apiKey) {
       if (!this.available()) throw new OperatorAiUnavailableError()
       const existing = await getAiProvider(deps.db, slug)
       if (!existing) throw new OperatorAiNotFoundError(slug)
-      await reconcile({ slug, apiKey })
+      await setAiProviderReconciliation(deps.db, slug, 'pending', null, true)
+      deps.onProviderUnavailable(slug)
+      try {
+        const governed = await reconcile({ targetSlug: slug, keyOverride: { slug, apiKey } })
+        await setAiProviderReconciliation(deps.db, slug, 'ready', null, false)
+        await publish(governed)
+      } catch (err) {
+        await failClosed(slug, 'error', true)
+        throw err
+      }
     },
 
     async remove(slug) {
       if (!this.available()) throw new OperatorAiUnavailableError()
-      const removed = await deleteAiProvider(deps.db, slug)
-      if (removed) await reconcile()
-      return removed
+      const existing = await getAiProvider(deps.db, slug)
+      if (existing) await setAiProviderReconciliation(deps.db, slug, 'deleting', null, false)
+      deps.onProviderUnavailable(slug)
+      try {
+        const governed = await reconcile({ targetSlug: slug })
+        if (existing) await deleteAiProvider(deps.db, slug)
+        await publish(governed)
+        return existing !== null
+      } catch (err) {
+        if (existing) await failClosed(slug, 'deleting', false)
+        throw err
+      }
+    },
+
+    async recover() {
+      if (!this.available()) throw new OperatorAiUnavailableError()
+      await quarantineUnsafeUnverified(await listAiProviders(deps.db))
+      const before = await listAiProviders(deps.db)
+      for (const record of before) {
+        if (record.reconciliationState !== 'ready' || !record.reconciledAt) deps.onProviderUnavailable(record.slug)
+      }
+      const governed = await reconcile({ recover: true })
+      const governedSlugs = new Set(governed.map((entry) => entry.id))
+      for (const record of before) {
+        if (record.reconciliationState === 'deleting') {
+          await deleteAiProvider(deps.db, record.slug)
+        } else if (record.reconciliationState === 'ready' || !record.credentialRequired) {
+          if (governedSlugs.has(record.slug)) {
+            await setAiProviderReconciliation(deps.db, record.slug, 'ready', null, false)
+          } else {
+            // This covers rows created before durable lifecycle state existed: if the sealed
+            // provider is absent, startup cannot recreate it without a key. Mark it visibly inert
+            // instead of continuing to present migrated metadata as ready.
+            await setAiProviderReconciliation(deps.db, record.slug, 'error', RECONCILIATION_FAILED, true)
+            deps.onProviderUnavailable(record.slug)
+          }
+        }
+      }
+      await publish(governed)
     },
   }
 }

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -179,6 +179,56 @@ export function mergeDesiredUpstreams(
   return [...bySlug.values()]
 }
 
+// Which store rows a provisioning pass may seal, route, and grant, and which slugs must keep
+// their sealed provider without one.
+export interface StoreUpstreamPlan {
+  upstreams: GovernedUpstream[]
+  preservedSlugs: string[]
+}
+
+export interface StoreUpstreamOptions {
+  // The slug whose lifecycle operation is driving this pass; it reconciles even though its
+  // durable state is still pending.
+  targetSlug?: string
+  // Admits every row a restart can replay on its own, which is any row that needs no key.
+  recover?: boolean
+  keyOverride?: { slug: string; apiKey: string }
+}
+
+// Turns the durable rows into the desired set the provisioner converges. A row is routed and
+// granted only with proof that its metadata matches its sealed resource; every other non-deleting
+// row is preserved instead, keeping its credential alive for an explicit retry while
+// ensureOperatorGrants revokes its authority. The boot path and every lifecycle write share this
+// so the two can never classify the same row differently.
+export function planStoreUpstreams(
+  envUpstreams: GovernedUpstream[],
+  records: OperatorAiProviderRecord[],
+  options: StoreUpstreamOptions = {},
+): StoreUpstreamPlan {
+  const selected = records.filter((record) => {
+    if (record.reconciliationState === 'deleting') return false
+    if (record.reconciliationState === 'ready') return record.reconciledAt !== null
+    if (record.slug === options.targetSlug) return true
+    return options.recover === true && !record.credentialRequired
+  })
+  const selectedSlugs = new Set(selected.map((record) => record.slug))
+  const preservedSlugs = records
+    .filter((record) => record.reconciliationState !== 'deleting' && !selectedSlugs.has(record.slug))
+    .map((record) => record.slug)
+  // Every non-deleting store row shadows the env entry with the same slug, including a preserved
+  // one. Otherwise this pass would seal the env key onto the very provider it is required to
+  // leave untouched, and re-grant it while its durable state still says error.
+  const shadowedEnvSlugs = new Set(records.filter((record) => record.reconciliationState !== 'deleting').map((record) => record.slug))
+  return {
+    upstreams: mergeDesiredUpstreams(
+      envUpstreams.filter((upstream) => !shadowedEnvSlugs.has(upstream.id)),
+      selected,
+      options.keyOverride,
+    ),
+    preservedSlugs,
+  }
+}
+
 export interface OperatorAiManager {
   available(): boolean
   list(): Promise<OperatorAiProviderView[]>
@@ -216,35 +266,11 @@ export interface OperatorAiManagerDeps {
 export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAiManager {
   const RECONCILIATION_FAILED = 'reconciliation_failed'
 
-  async function reconcile(options: {
-    targetSlug?: string
-    keyOverride?: { slug: string; apiKey: string }
-    recover?: boolean
-  }): Promise<{ id: string; resourceIdentifier: string }[]> {
+  async function reconcile(options: StoreUpstreamOptions = {}): Promise<{ id: string; resourceIdentifier: string }[]> {
     const identity = deps.resolveIdentity()
     if (!identity) throw new OperatorAiUnavailableError()
-    const records = await listAiProviders(deps.db)
-    const selected = records.filter((record) => {
-      if (record.reconciliationState === 'deleting') return false
-      if (record.reconciliationState === 'ready') return record.reconciledAt !== null
-      if (record.slug === options.targetSlug) return true
-      return options.recover === true && !record.credentialRequired
-    })
-    const selectedSlugs = new Set(selected.map((record) => record.slug))
-    // A row waiting for a credential cannot be replayed after restart because plaintext keys are
-    // intentionally never stored. Retain any already-sealed provider while revoking its grant;
-    // the operator must retry the mutation with the key to make it ready again.
-    const preservedSlugs = records
-      .filter((record) => record.reconciliationState !== 'deleting' && !selectedSlugs.has(record.slug))
-      .map((record) => record.slug)
-    // Every non-deleting store row shadows the env entry with the same slug, including a failed
-    // row that is currently preserved rather than selected. Otherwise an unrelated lifecycle
-    // operation could overwrite that row's sealed key/resource with the env configuration and
-    // accidentally re-grant it while its durable state still says error.
-    const shadowedEnvSlugs = new Set(records.filter((record) => record.reconciliationState !== 'deleting').map((record) => record.slug))
-    const envUpstreams = deps.envUpstreams.filter((upstream) => !shadowedEnvSlugs.has(upstream.id))
-    const upstreams = mergeDesiredUpstreams(envUpstreams, selected, options.keyOverride)
-    return provisionGovernedUpstreams(deps.admin, identity.zoneId, identity.llm.applicationId, upstreams, preservedSlugs)
+    const plan = planStoreUpstreams(deps.envUpstreams, await listAiProviders(deps.db), options)
+    return provisionGovernedUpstreams(deps.admin, identity.zoneId, identity.llm.applicationId, plan.upstreams, plan.preservedSlugs)
   }
 
   async function publish(governed: { id: string; resourceIdentifier: string }[]): Promise<void> {
@@ -420,7 +446,12 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
 
     async recover() {
       if (!this.available()) throw new OperatorAiUnavailableError()
-      await quarantineUnsafeUnverified(await listAiProviders(deps.db))
+      const records = await listAiProviders(deps.db)
+      // This runs on every rotation tick, not only at boot, so that a row left behind by a failed
+      // write still converges on its own. A fully reconciled store has nothing to replay, and
+      // repeating the pass would re-seal every upstream to reach the state it is already in.
+      if (records.every((record) => record.reconciliationState === 'ready' && record.reconciledAt !== null)) return
+      await quarantineUnsafeUnverified(records)
       const before = await listAiProviders(deps.db)
       for (const record of before) {
         if (record.reconciliationState !== 'ready' || !record.reconciledAt) deps.onProviderUnavailable(record.slug)

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -382,7 +382,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
       const endpointMoved = baseUrl !== existing.baseUrl
       if ((endpointMoved || existing.credentialRequired) && !patch.apiKey) throw new OperatorAiKeyRequiredError(slug)
       const credentialRequired = endpointMoved || existing.credentialRequired || patch.apiKey !== undefined
-      await upsertAiProvider(deps.db, {
+      const claimed = await upsertAiProvider(deps.db, {
         slug,
         label: patch.label ?? existing.label,
         baseUrl,
@@ -394,6 +394,9 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
         reconciliationErrorCode: null,
         credentialRequired,
       })
+      // A remove that landed since the read above already tombstoned the row, and the store
+      // refuses to revive it.
+      if (!claimed) throw new OperatorAiNotFoundError(slug)
       deps.onProviderUnavailable(slug)
       try {
         const governed = await reconcile({
@@ -415,7 +418,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
       if (!this.available()) throw new OperatorAiUnavailableError()
       const existing = await getAiProvider(deps.db, slug)
       if (!existing || existing.reconciliationState === 'deleting') throw new OperatorAiNotFoundError(slug)
-      await setAiProviderReconciliation(deps.db, slug, 'pending', null, true)
+      if (!(await setAiProviderReconciliation(deps.db, slug, 'pending', null, true))) throw new OperatorAiNotFoundError(slug)
       deps.onProviderUnavailable(slug)
       try {
         const governed = await reconcile({ targetSlug: slug, keyOverride: { slug, apiKey } })

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -11,6 +11,7 @@ import { GovernedUpstream, llmProviderIdentifier, llmResourceIdentifier, provisi
 import {
   deleteAiProvider,
   getAiProvider,
+  insertAiProvider,
   listAiProviders,
   setAiProviderReconciliation,
   upsertAiProvider,
@@ -95,14 +96,20 @@ export class OperatorAiNotFoundError extends Error {
   }
 }
 
-// Raised when an update moves a provider's endpoint without supplying the key to seal for it.
-// The sealed key is bound to the provider slug rather than the URL, so reconciling a changed
-// baseUrl without a new key would re-point the existing credential at the new endpoint and hand
-// it to whoever operates that host on the next call. Requiring the key makes the two move as one
-// operation, and the old credential is replaced rather than forwarded.
+export class OperatorAiConflictError extends Error {
+  constructor(slug: string) {
+    super(`operator provider '${slug}' already exists`)
+    this.name = 'OperatorAiConflictError'
+  }
+}
+
+// Raised when reconciliation cannot safely continue without receiving the key again. This
+// includes an endpoint move (the old credential must never be forwarded to a new host) and a
+// missing sealed provider, which cannot be recreated from metadata because plaintext is never
+// retained.
 export class OperatorAiKeyRequiredError extends Error {
   constructor(slug: string) {
-    super(`operator provider '${slug}' requires a new api key when its base url changes`)
+    super(`operator provider '${slug}' requires an api key to reconcile`)
     this.name = 'OperatorAiKeyRequiredError'
   }
 }
@@ -246,6 +253,10 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
     deps.onRegistryChange(buildStoreProviderConfigs(records, resourceBySlug, deps.gatewayUrl, deps.governedFetch))
   }
 
+  function requireGovernedTarget(governed: { id: string }[], slug: string): void {
+    if (!governed.some((entry) => entry.id === slug)) throw new OperatorAiKeyRequiredError(slug)
+  }
+
   async function markFailure(slug: string, state: 'error' | 'deleting', credentialRequired: boolean): Promise<void> {
     await setAiProviderReconciliation(deps.db, slug, state, RECONCILIATION_FAILED, credentialRequired).catch(() => {})
   }
@@ -308,7 +319,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
 
     async create(input) {
       if (!this.available()) throw new OperatorAiUnavailableError()
-      await upsertAiProvider(deps.db, {
+      const inserted = await insertAiProvider(deps.db, {
         slug: input.slug,
         label: input.label,
         baseUrl: input.baseUrl,
@@ -320,9 +331,11 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
         reconciliationErrorCode: null,
         credentialRequired: true,
       })
+      if (!inserted) throw new OperatorAiConflictError(input.slug)
       deps.onProviderUnavailable(input.slug)
       try {
         const governed = await reconcile({ targetSlug: input.slug, keyOverride: { slug: input.slug, apiKey: input.apiKey } })
+        requireGovernedTarget(governed, input.slug)
         const record = await setAiProviderReconciliation(deps.db, input.slug, 'ready', null, false)
         if (!record) throw new OperatorAiNotFoundError(input.slug)
         await publish(governed)
@@ -359,12 +372,13 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
           targetSlug: slug,
           keyOverride: patch.apiKey ? { slug, apiKey: patch.apiKey } : undefined,
         })
+        requireGovernedTarget(governed, slug)
         const record = await setAiProviderReconciliation(deps.db, slug, 'ready', null, false)
         if (!record) throw new OperatorAiNotFoundError(slug)
         await publish(governed)
         return toView(record)
       } catch (err) {
-        await failClosed(slug, 'error', credentialRequired)
+        await failClosed(slug, 'error', credentialRequired || err instanceof OperatorAiKeyRequiredError)
         throw err
       }
     },
@@ -377,6 +391,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
       deps.onProviderUnavailable(slug)
       try {
         const governed = await reconcile({ targetSlug: slug, keyOverride: { slug, apiKey } })
+        requireGovernedTarget(governed, slug)
         await setAiProviderReconciliation(deps.db, slug, 'ready', null, false)
         await publish(governed)
       } catch (err) {

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -349,7 +349,9 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
     async update(slug, patch) {
       if (!this.available()) throw new OperatorAiUnavailableError()
       const existing = await getAiProvider(deps.db, slug)
-      if (!existing) throw new OperatorAiNotFoundError(slug)
+      // A tombstone's only valid transition is finishing its delete; editing or rotating it would
+      // seal a fresh credential for an endpoint the operator already asked to destroy.
+      if (!existing || existing.reconciliationState === 'deleting') throw new OperatorAiNotFoundError(slug)
       const baseUrl = patch.baseUrl ?? existing.baseUrl
       const endpointMoved = baseUrl !== existing.baseUrl
       if ((endpointMoved || existing.credentialRequired) && !patch.apiKey) throw new OperatorAiKeyRequiredError(slug)
@@ -386,7 +388,7 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
     async rotateKey(slug, apiKey) {
       if (!this.available()) throw new OperatorAiUnavailableError()
       const existing = await getAiProvider(deps.db, slug)
-      if (!existing) throw new OperatorAiNotFoundError(slug)
+      if (!existing || existing.reconciliationState === 'deleting') throw new OperatorAiNotFoundError(slug)
       await setAiProviderReconciliation(deps.db, slug, 'pending', null, true)
       deps.onProviderUnavailable(slug)
       try {

--- a/apps/api/src/operator-ai-manager.ts
+++ b/apps/api/src/operator-ai-manager.ts
@@ -230,7 +230,13 @@ export function createOperatorAiManager(deps: OperatorAiManagerDeps): OperatorAi
     const preservedSlugs = records
       .filter((record) => record.reconciliationState !== 'deleting' && !selectedSlugs.has(record.slug))
       .map((record) => record.slug)
-    const upstreams = mergeDesiredUpstreams(deps.envUpstreams, selected, options.keyOverride)
+    // Every non-deleting store row shadows the env entry with the same slug, including a failed
+    // row that is currently preserved rather than selected. Otherwise an unrelated lifecycle
+    // operation could overwrite that row's sealed key/resource with the env configuration and
+    // accidentally re-grant it while its durable state still says error.
+    const shadowedEnvSlugs = new Set(records.filter((record) => record.reconciliationState !== 'deleting').map((record) => record.slug))
+    const envUpstreams = deps.envUpstreams.filter((upstream) => !shadowedEnvSlugs.has(upstream.id))
+    const upstreams = mergeDesiredUpstreams(envUpstreams, selected, options.keyOverride)
     return provisionGovernedUpstreams(deps.admin, identity.zoneId, identity.llm.applicationId, upstreams, preservedSlugs)
   }
 

--- a/apps/api/src/operator-ai-store.ts
+++ b/apps/api/src/operator-ai-store.ts
@@ -104,6 +104,35 @@ export interface ProviderUpsert {
   credentialRequired: boolean
 }
 
+// Inserts a new provider without replacing an existing slug. POST and PATCH have distinct
+// lifecycle semantics: a duplicate create must not silently take a live provider offline or
+// replace its metadata, while PATCH deliberately uses the upsert helper below.
+export async function insertAiProvider(db: Queryable, input: ProviderUpsert): Promise<OperatorAiProviderRecord | null> {
+  const { rows } = await db.query<ProviderRow>(
+    `INSERT INTO operator_ai_providers
+       (slug, label, base_url, models, context_window, enabled, auth_config, reconciliation_state,
+        reconciliation_error_code, credential_required, reconciled_at, sort_order)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::jsonb, $8, $9, $10, NULL,
+             (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM operator_ai_providers))
+     ON CONFLICT (slug) DO NOTHING
+     RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
+               reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
+    [
+      input.slug,
+      input.label,
+      input.baseUrl,
+      JSON.stringify(input.models),
+      input.contextWindow,
+      input.enabled,
+      JSON.stringify(input.auth),
+      input.reconciliationState,
+      input.reconciliationErrorCode,
+      input.credentialRequired,
+    ],
+  )
+  return rows[0] ? toRecord(rows[0]) : null
+}
+
 // Lists every configured provider in display order, newest fields included. Read on boot to
 // build the gateway and on each registry change to rebuild it.
 export async function listAiProviders(db: Queryable): Promise<OperatorAiProviderRecord[]> {

--- a/apps/api/src/operator-ai-store.ts
+++ b/apps/api/src/operator-ai-store.ts
@@ -66,11 +66,16 @@ interface ProviderRow {
   reconciliation_state: string
   reconciliation_error_code: string | null
   credential_required: boolean
-  reconciled_at: string | null
+  reconciled_at: string | Date | null
 }
 
 function toReconciliationState(value: string): OperatorAiReconciliationState {
-  return value === 'pending' || value === 'error' || value === 'deleting' ? value : 'ready'
+  if (value === 'ready' || value === 'pending' || value === 'error' || value === 'deleting') return value
+  return 'error'
+}
+
+function toReconciledAt(value: string | Date | null): string | null {
+  return value instanceof Date ? value.toISOString() : value
 }
 
 function toRecord(row: ProviderRow): OperatorAiProviderRecord {
@@ -87,7 +92,7 @@ function toRecord(row: ProviderRow): OperatorAiProviderRecord {
     reconciliationState: toReconciliationState(row.reconciliation_state),
     reconciliationErrorCode: row.reconciliation_error_code,
     credentialRequired: row.credential_required,
-    reconciledAt: row.reconciled_at,
+    reconciledAt: toReconciledAt(row.reconciled_at),
   }
 }
 

--- a/apps/api/src/operator-ai-store.ts
+++ b/apps/api/src/operator-ai-store.ts
@@ -162,8 +162,9 @@ export async function getAiProvider(db: Queryable, slug: string): Promise<Operat
 
 // Inserts or replaces a provider's metadata. The sort order places a new provider at the end
 // while preserving an existing one's position, so the failover order an operator arranged is
-// stable across edits.
-export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Promise<OperatorAiProviderRecord> {
+// stable across edits. Returns null when the slug is a delete tombstone, which no metadata write
+// may revive; a concurrent remove therefore always wins over an edit that read the row first.
+export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Promise<OperatorAiProviderRecord | null> {
   const { rows } = await db.query<ProviderRow>(
     `INSERT INTO operator_ai_providers
        (slug, label, base_url, models, context_window, enabled, auth_config, reconciliation_state,
@@ -183,6 +184,7 @@ export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Pr
            credential_required = EXCLUDED.credential_required,
            reconciled_at = NULL,
            updated_at = now()
+     WHERE operator_ai_providers.reconciliation_state <> 'deleting'
      RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
                reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
     [
@@ -198,11 +200,13 @@ export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Pr
       input.credentialRequired,
     ],
   )
-  return toRecord(rows[0])
+  return rows[0] ? toRecord(rows[0]) : null
 }
 
 // Advances only the durable reconciliation fields. Error codes are deliberately low-cardinality
-// internal values; provider responses and credentials never enter this table.
+// internal values; provider responses and credentials never enter this table. A delete tombstone
+// accepts only a write that keeps it one, so a lifecycle operation racing a remove cannot revive
+// the row it already agreed to destroy. Returns null when no row matched.
 export async function setAiProviderReconciliation(
   db: Queryable,
   slug: string,
@@ -217,7 +221,7 @@ export async function setAiProviderReconciliation(
             credential_required = $4,
             reconciled_at = CASE WHEN $2 = 'ready' THEN now() ELSE reconciled_at END,
             updated_at = now()
-      WHERE slug = $1
+      WHERE slug = $1 AND (reconciliation_state <> 'deleting' OR $2 = 'deleting')
       RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
                 reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
     [slug, state, errorCode, credentialRequired],

--- a/apps/api/src/operator-ai-store.ts
+++ b/apps/api/src/operator-ai-store.ts
@@ -7,6 +7,8 @@ import type { Queryable } from './db.js'
 
 export const PROVIDER_SLUG_PATTERN = /^[a-z0-9_]{1,32}$/
 
+export type OperatorAiReconciliationState = 'ready' | 'pending' | 'error' | 'deleting'
+
 // One configured upstream the Operator may route a model call through. The key is never held
 // here; it is sealed into the matching Caracal provider. models is the set of model ids the
 // upstream serves behind one endpoint and key, each surfaced to the gateway as its own
@@ -20,6 +22,10 @@ export interface OperatorAiProviderRecord {
   enabled: boolean
   sortOrder: number
   auth: AuthPlacement
+  reconciliationState: OperatorAiReconciliationState
+  reconciliationErrorCode: string | null
+  credentialRequired: boolean
+  reconciledAt: string | null
 }
 
 // Where the gateway injects the sealed key for this upstream. Defaults to an Authorization
@@ -57,6 +63,14 @@ interface ProviderRow {
   enabled: boolean
   sort_order: number
   auth_config: unknown
+  reconciliation_state: string
+  reconciliation_error_code: string | null
+  credential_required: boolean
+  reconciled_at: string | null
+}
+
+function toReconciliationState(value: string): OperatorAiReconciliationState {
+  return value === 'pending' || value === 'error' || value === 'deleting' ? value : 'ready'
 }
 
 function toRecord(row: ProviderRow): OperatorAiProviderRecord {
@@ -70,6 +84,10 @@ function toRecord(row: ProviderRow): OperatorAiProviderRecord {
     enabled: row.enabled,
     sortOrder: row.sort_order,
     auth: toAuth(row.auth_config),
+    reconciliationState: toReconciliationState(row.reconciliation_state),
+    reconciliationErrorCode: row.reconciliation_error_code,
+    credentialRequired: row.credential_required,
+    reconciledAt: row.reconciled_at,
   }
 }
 
@@ -81,13 +99,17 @@ export interface ProviderUpsert {
   contextWindow: number
   enabled: boolean
   auth: AuthPlacement
+  reconciliationState: OperatorAiReconciliationState
+  reconciliationErrorCode: string | null
+  credentialRequired: boolean
 }
 
 // Lists every configured provider in display order, newest fields included. Read on boot to
 // build the gateway and on each registry change to rebuild it.
 export async function listAiProviders(db: Queryable): Promise<OperatorAiProviderRecord[]> {
   const { rows } = await db.query<ProviderRow>(
-    `SELECT slug, label, base_url, models, context_window, enabled, sort_order, auth_config
+    `SELECT slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
+            reconciliation_state, reconciliation_error_code, credential_required, reconciled_at
        FROM operator_ai_providers
       ORDER BY sort_order, slug`,
   )
@@ -96,7 +118,8 @@ export async function listAiProviders(db: Queryable): Promise<OperatorAiProvider
 
 export async function getAiProvider(db: Queryable, slug: string): Promise<OperatorAiProviderRecord | null> {
   const { rows } = await db.query<ProviderRow>(
-    `SELECT slug, label, base_url, models, context_window, enabled, sort_order, auth_config
+    `SELECT slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
+            reconciliation_state, reconciliation_error_code, credential_required, reconciled_at
        FROM operator_ai_providers WHERE slug = $1`,
     [slug],
   )
@@ -108,8 +131,10 @@ export async function getAiProvider(db: Queryable, slug: string): Promise<Operat
 // stable across edits.
 export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Promise<OperatorAiProviderRecord> {
   const { rows } = await db.query<ProviderRow>(
-    `INSERT INTO operator_ai_providers (slug, label, base_url, models, context_window, enabled, auth_config, sort_order)
-     VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::jsonb,
+    `INSERT INTO operator_ai_providers
+       (slug, label, base_url, models, context_window, enabled, auth_config, reconciliation_state,
+        reconciliation_error_code, credential_required, reconciled_at, sort_order)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::jsonb, $8, $9, $10, NULL,
              COALESCE((SELECT sort_order FROM operator_ai_providers WHERE slug = $1),
                       (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM operator_ai_providers)))
      ON CONFLICT (slug) DO UPDATE
@@ -119,11 +144,51 @@ export async function upsertAiProvider(db: Queryable, input: ProviderUpsert): Pr
            context_window = EXCLUDED.context_window,
            enabled = EXCLUDED.enabled,
            auth_config = EXCLUDED.auth_config,
+           reconciliation_state = EXCLUDED.reconciliation_state,
+           reconciliation_error_code = EXCLUDED.reconciliation_error_code,
+           credential_required = EXCLUDED.credential_required,
+           reconciled_at = NULL,
            updated_at = now()
-     RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config`,
-    [input.slug, input.label, input.baseUrl, JSON.stringify(input.models), input.contextWindow, input.enabled, JSON.stringify(input.auth)],
+     RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
+               reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
+    [
+      input.slug,
+      input.label,
+      input.baseUrl,
+      JSON.stringify(input.models),
+      input.contextWindow,
+      input.enabled,
+      JSON.stringify(input.auth),
+      input.reconciliationState,
+      input.reconciliationErrorCode,
+      input.credentialRequired,
+    ],
   )
   return toRecord(rows[0])
+}
+
+// Advances only the durable reconciliation fields. Error codes are deliberately low-cardinality
+// internal values; provider responses and credentials never enter this table.
+export async function setAiProviderReconciliation(
+  db: Queryable,
+  slug: string,
+  state: OperatorAiReconciliationState,
+  errorCode: string | null,
+  credentialRequired: boolean,
+): Promise<OperatorAiProviderRecord | null> {
+  const { rows } = await db.query<ProviderRow>(
+    `UPDATE operator_ai_providers
+        SET reconciliation_state = $2,
+            reconciliation_error_code = $3,
+            credential_required = $4,
+            reconciled_at = CASE WHEN $2 = 'ready' THEN now() ELSE reconciled_at END,
+            updated_at = now()
+      WHERE slug = $1
+      RETURNING slug, label, base_url, models, context_window, enabled, sort_order, auth_config,
+                reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
+    [slug, state, errorCode, credentialRequired],
+  )
+  return rows[0] ? toRecord(rows[0]) : null
 }
 
 export async function deleteAiProvider(db: Queryable, slug: string): Promise<boolean> {

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -74,6 +74,7 @@ import type { Evidence } from '../operator-research.js'
 import { retrieveDocs } from '../operator-docs.js'
 import { summarizeHistory, type ConversationFacts } from '../operator-memory.js'
 import {
+  OperatorAiConflictError,
   OperatorAiKeyRequiredError,
   OperatorAiNotFoundError,
   OperatorAiUnavailableError,
@@ -1230,6 +1231,10 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
     }
     if (err instanceof OperatorAiNotFoundError) {
       reply.code(404).send({ error: 'provider_not_found' })
+      return true
+    }
+    if (err instanceof OperatorAiConflictError) {
+      reply.code(409).send({ error: 'provider_already_exists' })
       return true
     }
     if (err instanceof OperatorAiKeyRequiredError) {

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -1222,8 +1222,9 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
   const ProviderSlugParams = z.object({ slug: ProviderSlug })
 
   // Maps a manager error to its HTTP shape: a missing governance prerequisite is a 409 the
-  // console explains, and an unknown provider is a 404. Any other error propagates to the
-  // shared handler.
+  // console explains, an unknown provider is a 404, a duplicate slug is a 409 rather than a
+  // silent replacement, and reconciliation that cannot continue without the key is a 400. Any
+  // other error propagates to the shared handler.
   function sendAiError(reply: FastifyReply, err: unknown): boolean {
     if (err instanceof OperatorAiUnavailableError) {
       reply.code(409).send({ error: 'governed_execution_unconfigured' })
@@ -1238,7 +1239,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       return true
     }
     if (err instanceof OperatorAiKeyRequiredError) {
-      reply.code(400).send({ error: 'api_key_required_for_base_url_change' })
+      reply.code(400).send({ error: 'api_key_required' })
       return true
     }
     return false

--- a/apps/api/src/system-zone.ts
+++ b/apps/api/src/system-zone.ts
@@ -117,7 +117,7 @@ function sanitizeSlug(id: string): string {
   )
 }
 
-function llmProviderIdentifier(id: string): `provider://${string}` {
+export function llmProviderIdentifier(id: string): `provider://${string}` {
   return `${LLM_PROVIDER_PREFIX}${sanitizeSlug(id)}`
 }
 
@@ -251,12 +251,16 @@ async function pruneOrphanedProviders(admin: AdminClient, zoneId: string, desire
 // whose provider cannot be resolved (no key supplied and none sealed before) is skipped, so it
 // neither binds a dead credential nor receives a grant. Safe to run with an empty set: it
 // prunes any previously governed upstream's provider and reconciles the grant set to empty.
-// Returns the upstream-id to resource-identifier mapping the runtime routes through.
+// preservedUpstreamIds retain sealed providers for credential-dependent pending/error rows but
+// deliberately do not grant or route them; a later explicit retry can reuse/replace the sealed
+// provider without persisting plaintext key material. Returns the upstream-id to
+// resource-identifier mapping the runtime routes through.
 export async function provisionGovernedUpstreams(
   admin: AdminClient,
   zoneId: string,
   operatorAppId: string,
   upstreams: GovernedUpstream[],
+  preservedUpstreamIds: string[] = [],
 ): Promise<{ id: string; resourceIdentifier: string }[]> {
   const governed: { id: string; resourceIdentifier: string }[] = []
   for (const upstream of upstreams) {
@@ -265,7 +269,11 @@ export async function provisionGovernedUpstreams(
     const resourceIdentifier = await ensureLlmResource(admin, zoneId, upstream, providerId)
     governed.push({ id: upstream.id, resourceIdentifier })
   }
-  await pruneOrphanedProviders(admin, zoneId, new Set(upstreams.map((upstream) => llmProviderIdentifier(upstream.id))))
+  const retainedProviderIdentifiers = new Set([
+    ...upstreams.map((upstream) => llmProviderIdentifier(upstream.id)),
+    ...preservedUpstreamIds.map(llmProviderIdentifier),
+  ])
+  await pruneOrphanedProviders(admin, zoneId, retainedProviderIdentifiers)
   await ensureOperatorGrants(
     admin,
     zoneId,
@@ -293,6 +301,7 @@ export async function provisionSystemZone(
   findZoneBySlug: FindZoneBySlug,
   roles: OperatorRoleScopes,
   governedUpstreams: GovernedUpstream[] = [],
+  preservedGovernedUpstreamIds: string[] = [],
 ): Promise<SystemZoneIdentity> {
   const zone = await ensureSystemZone(admin, findZoneBySlug)
   await ensureControlResource(admin, zone.id, audience)
@@ -320,7 +329,7 @@ export async function provisionSystemZone(
   // Always reconcile governed upstreams, even with an empty set, so a previously governed
   // upstream that has been removed from config is pruned and its grant revoked rather than
   // left authorized with a live sealed key.
-  const governedResources = await provisionGovernedUpstreams(admin, zone.id, llmId, governedUpstreams)
+  const governedResources = await provisionGovernedUpstreams(admin, zone.id, llmId, governedUpstreams, preservedGovernedUpstreamIds)
   return {
     zoneId: zone.id,
     llm: { applicationId: llmId, clientSecret: llmSecret },

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -1151,6 +1151,10 @@ export interface OperatorAiProvider {
   contextWindow: number;
   enabled: boolean;
   auth: OperatorAiAuth;
+  reconciliationState: "ready" | "pending" | "error" | "deleting";
+  reconciliationErrorCode: string | null;
+  credentialRequired: boolean;
+  reconciledAt: string | null;
 }
 
 export interface OperatorAiProviderList {

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -93,6 +93,10 @@ function writeErrorMessage(err: unknown): string {
       return "Self-governance is not configured, so a key cannot be sealed.";
     if (err.code === "invalid_provider")
       return "Some fields are invalid. Check the form and try again.";
+    if (err.code === "provider_already_exists")
+      return "A model endpoint with that id already exists.";
+    if (err.code === "api_key_required_for_base_url_change")
+      return "This endpoint needs a new API key before it can be updated.";
     if (err.code === "provider_not_found") return "That model endpoint no longer exists.";
   }
   return "The change could not be saved. Try again.";
@@ -488,10 +492,10 @@ function EndpointField({ value, onChange }: { value: string; onChange: (value: s
 
 // The add and edit form. Adding starts empty so the operator supplies only what matters: an
 // OpenAI-compatible endpoint, a key, and the model ids the endpoint serves. The slug defaults
-// from the label. Editing locks the slug and omits the key, which is changed through rotate. The
-// provider and resource details Caracal sets automatically (api-key auth, an Authorization Bearer
-// header, and the llm:invoke and agent:lifecycle scopes) are explained
-// rather than asked for.
+// from the label. Editing locks the slug and normally omits the key, which is changed through
+// rotate; a credential-dependent recovery asks for it again because plaintext is never retained.
+// The provider and resource details Caracal sets automatically (api-key auth, an Authorization
+// Bearer header, and the llm:invoke and agent:lifecycle scopes) are explained rather than asked for.
 function ProviderFormModal({
   open,
   editing,
@@ -582,7 +586,8 @@ function ProviderFormModal({
   // Moving an endpoint re-seals the credential, so the key must be supplied with the change: the
   // sealed key is never carried across to a new host.
   const endpointMoved = editing !== null && baseUrl.trim() !== editing.baseUrl;
-  const keyRequired = editing === null || endpointMoved;
+  const replacementKeyRequired = editing !== null && (endpointMoved || editing.credentialRequired);
+  const keyRequired = editing === null || replacementKeyRequired;
   const valid =
     slug.length > 0 &&
     !slugTaken &&
@@ -613,7 +618,7 @@ function ProviderFormModal({
             models,
             contextWindow: ctx,
             auth,
-            ...(endpointMoved ? { apiKey } : {}),
+            ...(replacementKeyRequired ? { apiKey } : {}),
           },
         });
       } else {
@@ -692,7 +697,9 @@ function ProviderFormModal({
               info={
                 endpointMoved
                   ? "Changing the endpoint re-seals the credential, so a key for the new endpoint is required. The previous key is replaced, never forwarded."
-                  : "Sent once and sealed into Caracal; it is never stored in the console or read back."
+                  : editing?.credentialRequired
+                    ? "The previous reconciliation could not be recovered without the credential. Supply the key again to retry safely."
+                    : "Sent once and sealed into Caracal; it is never stored in the console or read back."
               }
               value={apiKey}
               onChange={(event) => setApiKey(event.target.value)}

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -207,6 +207,17 @@ function OperatorPage() {
                         {provider.label}
                       </span>
                       {!provider.enabled ? <Badge tone="muted">Disabled</Badge> : null}
+                      {provider.reconciliationState === "pending" ? (
+                        <Badge tone="warning">Pending</Badge>
+                      ) : null}
+                      {provider.reconciliationState === "error" ? (
+                        <Badge tone="danger">
+                          {provider.credentialRequired ? "Retry with key" : "Reconcile failed"}
+                        </Badge>
+                      ) : null}
+                      {provider.reconciliationState === "deleting" ? (
+                        <Badge tone="warning">Removing</Badge>
+                      ) : null}
                     </div>
                     <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
                       {provider.baseUrl}

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -212,15 +212,32 @@ function OperatorPage() {
                       </span>
                       {!provider.enabled ? <Badge tone="muted">Disabled</Badge> : null}
                       {provider.reconciliationState === "pending" ? (
-                        <Badge tone="warning">Pending</Badge>
+                        <Badge
+                          tone="warning"
+                          title="Reconciliation is not complete. The Operator does not route to this endpoint yet."
+                        >
+                          Pending
+                        </Badge>
                       ) : null}
                       {provider.reconciliationState === "error" ? (
-                        <Badge tone="danger">
+                        <Badge
+                          tone="danger"
+                          title={
+                            provider.credentialRequired
+                              ? "Reconciliation failed and requires the API key before this endpoint can be retried."
+                              : "Reconciliation failed. Edit and save this endpoint to retry."
+                          }
+                        >
                           {provider.credentialRequired ? "Retry with key" : "Reconcile failed"}
                         </Badge>
                       ) : null}
                       {provider.reconciliationState === "deleting" ? (
-                        <Badge tone="warning">Removing</Badge>
+                        <Badge
+                          tone="warning"
+                          title="Removal is pending. Retry remove to finish deleting the sealed endpoint."
+                        >
+                          Removing
+                        </Badge>
                       ) : null}
                     </div>
                     <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -214,9 +214,13 @@ function OperatorPage() {
                       {provider.reconciliationState === "pending" ? (
                         <Badge
                           tone="warning"
-                          title="Reconciliation is not complete. The Operator does not route to this endpoint yet."
+                          title={
+                            provider.credentialRequired
+                              ? "Reconciliation did not complete and the API key was not retained. Supply it again to retry."
+                              : "Reconciliation is not complete. The Operator does not route to this endpoint yet."
+                          }
                         >
-                          Pending
+                          {provider.credentialRequired ? "Retry with key" : "Pending"}
                         </Badge>
                       ) : null}
                       {provider.reconciliationState === "error" ? (
@@ -255,25 +259,30 @@ function OperatorPage() {
                     </div>
                   </div>
                   <div className="flex flex-shrink-0 items-center gap-1.5">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      mutating
-                      onClick={() => {
-                        setEditing(provider);
-                        setFormOpen(true);
-                      }}
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      mutating
-                      onClick={() => setRotating(provider)}
-                    >
-                      Rotate key
-                    </Button>
+                    {/* A row awaiting removal accepts only a retried delete. */}
+                    {provider.reconciliationState !== "deleting" ? (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          mutating
+                          onClick={() => {
+                            setEditing(provider);
+                            setFormOpen(true);
+                          }}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          mutating
+                          onClick={() => setRotating(provider)}
+                        >
+                          Rotate key
+                        </Button>
+                      </>
+                    ) : null}
                     <Button
                       variant="ghost"
                       size="sm"

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -95,7 +95,7 @@ function writeErrorMessage(err: unknown): string {
       return "Some fields are invalid. Check the form and try again.";
     if (err.code === "provider_already_exists")
       return "A model endpoint with that id already exists.";
-    if (err.code === "api_key_required_for_base_url_change")
+    if (err.code === "api_key_required")
       return "This endpoint needs a new API key before it can be updated.";
     if (err.code === "provider_not_found") return "That model endpoint no longer exists.";
   }

--- a/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.down.sql
+++ b/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.down.sql
@@ -1,0 +1,11 @@
+-- Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+-- Caracal, a product of Garudex Labs
+--
+-- Reverses durable model-endpoint reconciliation state; development and CI only.
+
+ALTER TABLE public.operator_ai_providers
+    DROP CONSTRAINT IF EXISTS operator_ai_providers_reconciliation_state_check,
+    DROP COLUMN IF EXISTS reconciled_at,
+    DROP COLUMN IF EXISTS credential_required,
+    DROP COLUMN IF EXISTS reconciliation_error_code,
+    DROP COLUMN IF EXISTS reconciliation_state;

--- a/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.up.sql
+++ b/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.up.sql
@@ -12,3 +12,6 @@ ALTER TABLE public.operator_ai_providers
 ALTER TABLE public.operator_ai_providers
     ADD CONSTRAINT operator_ai_providers_reconciliation_state_check
         CHECK (reconciliation_state = ANY (ARRAY['ready'::text, 'pending'::text, 'error'::text, 'deleting'::text])) NOT VALID;
+
+ALTER TABLE public.operator_ai_providers
+    VALIDATE CONSTRAINT operator_ai_providers_reconciliation_state_check;

--- a/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.up.sql
+++ b/infra/postgres/migrations/0004_operator_ai_provider_reconciliation.up.sql
@@ -1,0 +1,14 @@
+-- Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+-- Caracal, a product of Garudex Labs
+--
+-- Makes model-endpoint reconciliation durable without storing plaintext credentials.
+
+ALTER TABLE public.operator_ai_providers
+    ADD COLUMN reconciliation_state text DEFAULT 'ready'::text NOT NULL,
+    ADD COLUMN reconciliation_error_code text,
+    ADD COLUMN credential_required boolean DEFAULT false NOT NULL,
+    ADD COLUMN reconciled_at timestamp with time zone;
+
+ALTER TABLE public.operator_ai_providers
+    ADD CONSTRAINT operator_ai_providers_reconciliation_state_check
+        CHECK (reconciliation_state = ANY (ARRAY['ready'::text, 'pending'::text, 'error'::text, 'deleting'::text])) NOT VALID;

--- a/tests/shared/test-utils/typescript/governed-operator-harness.ts
+++ b/tests/shared/test-utils/typescript/governed-operator-harness.ts
@@ -253,7 +253,16 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
         }
         const activeApp = app
         const activePool = pool
-        if (activeApp) await attempt(() => activeApp.close())
+        if (activeApp) {
+          await attempt(async () => {
+            // The test uses Node's global fetch, whose pooled keep-alive sockets can outlive
+            // the assertions (notably on Node 24). Begin Fastify shutdown first, then close
+            // those test-only connections so teardown does not wait for their idle timeout.
+            const appClosing = activeApp.close()
+            activeApp.server.closeAllConnections()
+            await appClosing
+          })
+        }
         if (activePool) await attempt(() => activePool.end())
         for (const fixture of [...fixtures].reverse()) await attempt(fixture.close)
         if (errors.length) throw new AggregateError(errors, 'governed Operator harness teardown failed')

--- a/tests/typescript/integration/postgres/schema.test.ts
+++ b/tests/typescript/integration/postgres/schema.test.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { insertAdminAuditRecord } from '../../../../packages/adminAudit/ts/src/index.js'
+import { insertAiProvider } from '../../../../apps/api/src/operator-ai-store.js'
 
 // These assertions are about SQL the unit suites can only match as text, so they need a real
 // database. Without one the tier is skipped rather than silently passing on a mock.
@@ -219,6 +220,33 @@ suite('operator provider reconciliation schema', () => {
       await expect(
         client.query(`UPDATE operator_ai_providers SET reconciliation_state = 'unknown' WHERE slug = $1`, [slug]),
       ).rejects.toThrow(/operator_ai_providers_reconciliation_state_check/i)
+    } finally {
+      await client.query('ROLLBACK').catch(() => {})
+      client.release()
+    }
+  })
+
+  it('rejects a duplicate lifecycle create without replacing the existing row', async () => {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const slug = `test_${randomUUID().replaceAll('-', '').slice(0, 20)}`
+      const input = {
+        slug,
+        label: 'Original',
+        baseUrl: 'https://original.example/v1',
+        models: ['original-model'],
+        contextWindow: 0,
+        enabled: true,
+        auth: { location: 'header' as const, headerName: 'Authorization', authScheme: 'Bearer' },
+        reconciliationState: 'pending' as const,
+        reconciliationErrorCode: null,
+        credentialRequired: true,
+      }
+      expect(await insertAiProvider(client, input)).toMatchObject({ slug, label: 'Original' })
+      expect(await insertAiProvider(client, { ...input, label: 'Replacement' })).toBeNull()
+      const { rows } = await client.query<{ label: string }>('SELECT label FROM operator_ai_providers WHERE slug = $1', [slug])
+      expect(rows[0]?.label).toBe('Original')
     } finally {
       await client.query('ROLLBACK').catch(() => {})
       client.release()

--- a/tests/typescript/integration/postgres/schema.test.ts
+++ b/tests/typescript/integration/postgres/schema.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'node:crypto'
 import pg from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { insertAdminAuditRecord } from '../../../../packages/adminAudit/ts/src/index.js'
-import { insertAiProvider } from '../../../../apps/api/src/operator-ai-store.js'
+import { insertAiProvider, setAiProviderReconciliation, upsertAiProvider } from '../../../../apps/api/src/operator-ai-store.js'
 
 // These assertions are about SQL the unit suites can only match as text, so they need a real
 // database. Without one the tier is skipped rather than silently passing on a mock.
@@ -247,6 +247,47 @@ suite('operator provider reconciliation schema', () => {
       expect(await insertAiProvider(client, { ...input, label: 'Replacement' })).toBeNull()
       const { rows } = await client.query<{ label: string }>('SELECT label FROM operator_ai_providers WHERE slug = $1', [slug])
       expect(rows[0]?.label).toBe('Original')
+    } finally {
+      await client.query('ROLLBACK').catch(() => {})
+      client.release()
+    }
+  })
+
+  it('refuses every lifecycle write that would revive a delete tombstone', async () => {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const slug = `test_${randomUUID().replaceAll('-', '').slice(0, 20)}`
+      const input = {
+        slug,
+        label: 'Doomed',
+        baseUrl: 'https://doomed.example/v1',
+        models: ['doomed-model'],
+        contextWindow: 0,
+        enabled: true,
+        auth: { location: 'header' as const, headerName: 'Authorization', authScheme: 'Bearer' },
+        reconciliationState: 'ready' as const,
+        reconciliationErrorCode: null,
+        credentialRequired: false,
+      }
+      await insertAiProvider(client, input)
+      expect(await setAiProviderReconciliation(client, slug, 'deleting', null, false)).toMatchObject({ reconciliationState: 'deleting' })
+
+      // An edit or rotation that read the row before the remove claimed it must lose the race
+      // in the database, not merely in the manager's pre-read check.
+      expect(await upsertAiProvider(client, { ...input, label: 'Resurrected', reconciliationState: 'pending' })).toBeNull()
+      expect(await setAiProviderReconciliation(client, slug, 'pending', null, true)).toBeNull()
+      expect(await setAiProviderReconciliation(client, slug, 'ready', null, false)).toBeNull()
+
+      const { rows } = await client.query<{ label: string; reconciliation_state: string }>(
+        'SELECT label, reconciliation_state FROM operator_ai_providers WHERE slug = $1',
+        [slug],
+      )
+      expect(rows[0]).toEqual({ label: 'Doomed', reconciliation_state: 'deleting' })
+      // Remove stays retryable: a write that keeps the tombstone is still allowed.
+      expect(await setAiProviderReconciliation(client, slug, 'deleting', 'reconciliation_failed', false)).toMatchObject({
+        reconciliationState: 'deleting',
+      })
     } finally {
       await client.query('ROLLBACK').catch(() => {})
       client.release()

--- a/tests/typescript/integration/postgres/schema.test.ts
+++ b/tests/typescript/integration/postgres/schema.test.ts
@@ -192,3 +192,36 @@ suite('admin audit hash chain', () => {
     }
   })
 })
+
+suite('operator provider reconciliation schema', () => {
+  it('defaults existing lifecycle writes to ready and enforces durable state values', async () => {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const slug = `test_${randomUUID().replaceAll('-', '').slice(0, 20)}`
+      const { rows } = await client.query<{
+        reconciliation_state: string
+        reconciliation_error_code: string | null
+        credential_required: boolean
+        reconciled_at: string | null
+      }>(
+        `INSERT INTO operator_ai_providers (slug, label, base_url)
+         VALUES ($1, 'Test', 'https://example.test/v1')
+         RETURNING reconciliation_state, reconciliation_error_code, credential_required, reconciled_at`,
+        [slug],
+      )
+      expect(rows[0]).toEqual({
+        reconciliation_state: 'ready',
+        reconciliation_error_code: null,
+        credential_required: false,
+        reconciled_at: null,
+      })
+      await expect(
+        client.query(`UPDATE operator_ai_providers SET reconciliation_state = 'unknown' WHERE slug = $1`, [slug]),
+      ).rejects.toThrow(/operator_ai_providers_reconciliation_state_check/i)
+    } finally {
+      await client.query('ROLLBACK').catch(() => {})
+      client.release()
+    }
+  })
+})

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -49,6 +49,8 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
           params as [string, string, string, string, number, boolean, string, StoreRow['reconciliation_state'], string | null, boolean]
         const existing = rows.get(slug)
         if (existing && sql.includes('ON CONFLICT (slug) DO NOTHING')) return { rows: [] }
+        // Mirror the tombstone guard: no metadata write revives a row a remove already claimed.
+        if (existing?.reconciliation_state === 'deleting') return { rows: [] }
         const row: StoreRow = {
           slug,
           label,
@@ -75,6 +77,7 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
         const [slug, reconciliationState, reconciliationErrorCode, credentialRequired] = params as [string, string, string | null, boolean]
         const row = rows.get(slug)
         if (!row) return { rows: [] }
+        if (row.reconciliation_state === 'deleting' && reconciliationState !== 'deleting') return { rows: [] }
         row.reconciliation_state = reconciliationState
         row.reconciliation_error_code = reconciliationErrorCode
         row.credential_required = credentialRequired

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -28,10 +28,10 @@ interface StoreRow {
   enabled: boolean
   sort_order: number
   auth_config: unknown
-  reconciliation_state: 'ready' | 'pending' | 'error' | 'deleting'
+  reconciliation_state: string
   reconciliation_error_code: string | null
   credential_required: boolean
-  reconciled_at: string | null
+  reconciled_at: string | Date | null
 }
 
 // An in-memory Queryable matching the store's four statements by their stable SQL shape, so the
@@ -41,6 +41,7 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
   let order = 0
   const db: Queryable = {
     query: async <T = unknown>(sql: string, params: unknown[] = []): Promise<{ rows: T[] }> => {
+      // Writes also contain `WHERE slug = $1`; keep all write shapes ahead of the read branch.
       if (sql.includes('INSERT INTO operator_ai_providers')) {
         const [slug, label, baseUrl, modelsJson, ctx, enabled, authJson, reconciliationState, reconciliationErrorCode, credentialRequired] =
           params as [string, string, string, string, number, boolean, string, StoreRow['reconciliation_state'], string | null, boolean]
@@ -69,12 +70,7 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
         return { rows: (had ? [{ slug }] : []) as T[] }
       }
       if (sql.includes('UPDATE operator_ai_providers')) {
-        const [slug, reconciliationState, reconciliationErrorCode, credentialRequired] = params as [
-          string,
-          StoreRow['reconciliation_state'],
-          string | null,
-          boolean,
-        ]
+        const [slug, reconciliationState, reconciliationErrorCode, credentialRequired] = params as [string, string, string | null, boolean]
         const row = rows.get(slug)
         if (!row) return { rows: [] }
         row.reconciliation_state = reconciliationState
@@ -399,6 +395,31 @@ describe('operator ai manager helpers', () => {
 })
 
 describe('operator ai manager lifecycle', () => {
+  it('fails closed on an unknown stored state and normalizes database timestamps', async () => {
+    const { manager, rows } = buildManager(IDENTITY)
+    rows.set('corrupt', {
+      slug: 'corrupt',
+      label: 'Corrupt',
+      base_url: 'https://api.example/v1',
+      models: ['model'],
+      context_window: 0,
+      enabled: true,
+      sort_order: 1,
+      auth_config: AUTH,
+      reconciliation_state: 'unexpected',
+      reconciliation_error_code: null,
+      credential_required: false,
+      reconciled_at: new Date('2026-08-20T00:00:00.000Z'),
+    })
+
+    expect(await manager.list()).toEqual([
+      expect.objectContaining({
+        reconciliationState: 'error',
+        reconciledAt: '2026-08-20T00:00:00.000Z',
+      }),
+    ])
+  })
+
   it('reports unavailable and refuses writes when no identity is resolved', async () => {
     const { manager } = buildManager(null)
     expect(manager.available()).toBe(false)

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -14,6 +14,7 @@ import {
   OperatorAiUnavailableError,
   OperatorAiNotFoundError,
   OperatorAiKeyRequiredError,
+  OperatorAiConflictError,
 } from '../../../../apps/api/src/operator-ai-manager.js'
 import type { ProviderConfig } from '../../../../apps/api/src/operator-gateway.js'
 import type { OperatorControlIdentity } from '../../../../apps/api/src/config.js'
@@ -44,6 +45,7 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
         const [slug, label, baseUrl, modelsJson, ctx, enabled, authJson, reconciliationState, reconciliationErrorCode, credentialRequired] =
           params as [string, string, string, string, number, boolean, string, StoreRow['reconciliation_state'], string | null, boolean]
         const existing = rows.get(slug)
+        if (existing && sql.includes('ON CONFLICT (slug) DO NOTHING')) return { rows: [] }
         const row: StoreRow = {
           slug,
           label,
@@ -467,16 +469,7 @@ describe('operator ai manager lifecycle', () => {
     expect(restarted.state.providers).toEqual([])
     expect(restarted.getPublished()).toEqual([])
 
-    const view = await restarted.manager.create({
-      slug: 'openai',
-      label: 'OpenAI',
-      baseUrl: 'https://api/v1',
-      models: ['gpt-5.5'],
-      contextWindow: 0,
-      apiKey: 'sk-create-retry',
-      enabled: true,
-      auth: AUTH,
-    })
+    const view = await restarted.manager.update('openai', { apiKey: 'sk-create-retry' })
     expect(view.reconciliationState).toBe('ready')
     expect(view.credentialRequired).toBe(false)
     expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
@@ -512,16 +505,7 @@ describe('operator ai manager lifecycle', () => {
     expect(restarted.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: true })
     expect(restarted.getPublished()).toEqual([])
 
-    await restarted.manager.create({
-      slug: 'openai',
-      label: 'OpenAI',
-      baseUrl: 'https://api/v1',
-      models: ['gpt-5.5'],
-      contextWindow: 0,
-      apiKey: 'sk-explicit-retry',
-      enabled: true,
-      auth: AUTH,
-    })
+    await restarted.manager.update('openai', { apiKey: 'sk-explicit-retry' })
     expect(restarted.state.providers[0].config_json.api_key).toBe('sk-explicit-retry')
     expect(restarted.state.resources).toHaveLength(1)
     expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
@@ -558,6 +542,38 @@ describe('operator ai manager lifecycle', () => {
     expect(failedProvider?.config_json.api_key).toBe('sk-store')
     expect(first.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: true })
     expect(first.getPublished().map((provider) => provider.id)).toEqual(['other'])
+  })
+
+  it('rejects a duplicate create without mutating the existing provider', async () => {
+    const { manager, rows, state, getPublished } = buildManager(IDENTITY)
+    await manager.create({
+      slug: 'openai',
+      label: 'Original',
+      baseUrl: 'https://original.example/v1',
+      models: ['original-model'],
+      contextWindow: 0,
+      apiKey: 'sk-original',
+      enabled: true,
+      auth: AUTH,
+    })
+
+    await expect(
+      manager.create({
+        slug: 'openai',
+        label: 'Replacement',
+        baseUrl: 'https://replacement.example/v1',
+        models: ['replacement-model'],
+        contextWindow: 0,
+        apiKey: 'sk-replacement',
+        enabled: true,
+        auth: AUTH,
+      }),
+    ).rejects.toBeInstanceOf(OperatorAiConflictError)
+
+    expect(rows.get('openai')).toMatchObject({ label: 'Original', base_url: 'https://original.example/v1' })
+    expect(state.providers[0].config_json.api_key).toBe('sk-original')
+    expect(state.resources[0].upstream_url).toBe('https://original.example/v1')
+    expect(getPublished().map((provider) => provider.id)).toEqual(['openai'])
   })
 
   it('marks migrated metadata with no sealed provider as credential-required on startup', async () => {
@@ -796,6 +812,30 @@ describe('operator ai manager lifecycle', () => {
     // The rejected edit changed nothing: the endpoint and its sealed key are both untouched.
     expect(state.providers[0].config_json.api_key).toBe('sk-1')
     expect(state.resources[0].upstream_url).toBe('https://api/v1')
+  })
+
+  it('marks a metadata-only update credential-required when the sealed provider disappeared', async () => {
+    const { manager, rows, state, getPublished } = buildManager(IDENTITY)
+    await manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-sealed',
+      enabled: true,
+      auth: AUTH,
+    })
+    state.providers = []
+
+    await expect(manager.update('openai', { label: 'Updated' })).rejects.toBeInstanceOf(OperatorAiKeyRequiredError)
+    expect(rows.get('openai')).toMatchObject({
+      label: 'Updated',
+      reconciliation_state: 'error',
+      reconciliation_error_code: 'reconciliation_failed',
+      credential_required: true,
+    })
+    expect(getPublished()).toEqual([])
   })
 
   it('re-seals the supplied key when the endpoint moves', async () => {

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -997,6 +997,36 @@ describe('operator ai manager lifecycle', () => {
     expect(restarted.getPublished()).toEqual([])
   })
 
+  it('refuses to edit or rotate a tombstone back into a live sealed endpoint', async () => {
+    const { manager, rows, state, getPublished, failNext } = buildManager(IDENTITY)
+    await manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-doomed',
+      enabled: true,
+      auth: AUTH,
+    })
+    failNext(`provider.delete:${state.providers[0].id}`)
+    await expect(manager.remove('openai')).rejects.toThrow('injected failure')
+    expect(rows.get('openai')?.reconciliation_state).toBe('deleting')
+
+    // Only a retried delete may act on a tombstone; a key supplied here would re-seal a
+    // credential for an endpoint the operator already asked to destroy.
+    await expect(manager.rotateKey('openai', 'sk-resurrected')).rejects.toBeInstanceOf(OperatorAiNotFoundError)
+    await expect(manager.update('openai', { label: 'Resurrected', apiKey: 'sk-resurrected' })).rejects.toBeInstanceOf(
+      OperatorAiNotFoundError,
+    )
+
+    expect(rows.get('openai')).toMatchObject({ label: 'OpenAI', reconciliation_state: 'deleting' })
+    expect(state.providers).toEqual([])
+    expect(getPublished()).toEqual([])
+    expect(await manager.remove('openai')).toBe(true)
+    expect(rows.has('openai')).toBe(false)
+  })
+
   it('cleans a stale sealed provider when legacy partial deletion already removed metadata', async () => {
     const { manager, rows, state, getPublished } = buildManager(IDENTITY)
     await manager.create({

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -27,6 +27,10 @@ interface StoreRow {
   enabled: boolean
   sort_order: number
   auth_config: unknown
+  reconciliation_state: 'ready' | 'pending' | 'error' | 'deleting'
+  reconciliation_error_code: string | null
+  credential_required: boolean
+  reconciled_at: string | null
 }
 
 // An in-memory Queryable matching the store's four statements by their stable SQL shape, so the
@@ -37,15 +41,8 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
   const db: Queryable = {
     query: async <T = unknown>(sql: string, params: unknown[] = []): Promise<{ rows: T[] }> => {
       if (sql.includes('INSERT INTO operator_ai_providers')) {
-        const [slug, label, baseUrl, modelsJson, ctx, enabled, authJson] = params as [
-          string,
-          string,
-          string,
-          string,
-          number,
-          boolean,
-          string,
-        ]
+        const [slug, label, baseUrl, modelsJson, ctx, enabled, authJson, reconciliationState, reconciliationErrorCode, credentialRequired] =
+          params as [string, string, string, string, number, boolean, string, StoreRow['reconciliation_state'], string | null, boolean]
         const existing = rows.get(slug)
         const row: StoreRow = {
           slug,
@@ -56,6 +53,10 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
           enabled,
           sort_order: existing?.sort_order ?? ++order,
           auth_config: JSON.parse(authJson),
+          reconciliation_state: reconciliationState,
+          reconciliation_error_code: reconciliationErrorCode,
+          credential_required: credentialRequired,
+          reconciled_at: null,
         }
         rows.set(slug, row)
         return { rows: [row] as T[] }
@@ -64,6 +65,21 @@ function fakeDb(): { db: Queryable; rows: Map<string, StoreRow> } {
         const [slug] = params as [string]
         const had = rows.delete(slug)
         return { rows: (had ? [{ slug }] : []) as T[] }
+      }
+      if (sql.includes('UPDATE operator_ai_providers')) {
+        const [slug, reconciliationState, reconciliationErrorCode, credentialRequired] = params as [
+          string,
+          StoreRow['reconciliation_state'],
+          string | null,
+          boolean,
+        ]
+        const row = rows.get(slug)
+        if (!row) return { rows: [] }
+        row.reconciliation_state = reconciliationState
+        row.reconciliation_error_code = reconciliationErrorCode
+        row.credential_required = credentialRequired
+        if (reconciliationState === 'ready') row.reconciled_at = '2026-08-20T00:00:00.000Z'
+        return { rows: [row] as T[] }
       }
       if (sql.includes('WHERE slug = $1')) {
         const [slug] = params as [string]
@@ -91,21 +107,29 @@ interface AdminState {
   calls: string[]
 }
 
-function fakeAdmin(): { admin: AdminClient; state: AdminState } {
+function fakeAdmin(): { admin: AdminClient; state: AdminState; failNext: (call: string) => void } {
   const state: AdminState = { providers: [], resources: [], policies: [], policySets: [], calls: [] }
+  let nextFailure: string | null = null
+  const recordCall = (call: string): void => {
+    state.calls.push(call)
+    if (nextFailure === call) {
+      nextFailure = null
+      throw new Error(`injected failure at ${call}`)
+    }
+  }
   let counter = 0
   const id = (p: string): string => `${p}-${++counter}`
   const admin = {
     providers: {
       list: async () => state.providers,
       create: async (_z: string, input: { identifier: string; config_json: Record<string, unknown> }) => {
-        state.calls.push(`provider.create:${input.identifier}`)
+        recordCall(`provider.create:${input.identifier}`)
         const provider = { id: id('prov'), identifier: input.identifier, config_json: input.config_json }
         state.providers.push(provider)
         return provider
       },
       patch: async (_z: string, pid: string, input: { config_json?: Record<string, unknown> }) => {
-        state.calls.push(`provider.patch:${pid}`)
+        recordCall(`provider.patch:${pid}`)
         const provider = state.providers.find((p) => p.id === pid)!
         // Mirror real PATCH: public config is replaced, the sealed key persists unless re-supplied.
         if (input.config_json) {
@@ -115,20 +139,20 @@ function fakeAdmin(): { admin: AdminClient; state: AdminState } {
         return provider
       },
       delete: async (_z: string, pid: string) => {
-        state.calls.push(`provider.delete:${pid}`)
+        recordCall(`provider.delete:${pid}`)
         state.providers = state.providers.filter((p) => p.id !== pid)
       },
     },
     resources: {
       list: async () => state.resources,
       create: async (_z: string, input: AdminState['resources'][number]) => {
-        state.calls.push(`resource.create:${input.identifier}`)
+        recordCall(`resource.create:${input.identifier}`)
         const resource = { ...input, id: id('res') }
         state.resources.push(resource)
         return resource
       },
       patch: async (_z: string, rid: string, input: Partial<AdminState['resources'][number]>) => {
-        state.calls.push(`resource.patch:${rid}`)
+        recordCall(`resource.patch:${rid}`)
         const resource = state.resources.find((r) => r.id === rid)!
         Object.assign(resource, input)
         return resource
@@ -165,7 +189,13 @@ function fakeAdmin(): { admin: AdminClient; state: AdminState } {
       },
     },
   }
-  return { admin: admin as unknown as AdminClient, state }
+  return {
+    admin: admin as unknown as AdminClient,
+    state,
+    failNext: (call: string) => {
+      nextFailure = call
+    },
+  }
 }
 
 // A governedFetch double that records the resource it is bound to, so a test can confirm
@@ -177,6 +207,12 @@ function fakeGovernedFetch(resourceIdentifier: string): typeof fetch {
 }
 
 const AUTH = { location: 'header' as const, headerName: 'Authorization', authScheme: 'Bearer' }
+const READY_STATE = {
+  reconciliationState: 'ready' as const,
+  reconciliationErrorCode: null,
+  credentialRequired: false,
+  reconciledAt: '2026-08-20T00:00:00.000Z',
+}
 const IDENTITY: OperatorControlIdentity = {
   zoneId: 'sys-zone',
   llm: { applicationId: 'op-app', clientSecret: 'secret' },
@@ -185,9 +221,14 @@ const IDENTITY: OperatorControlIdentity = {
   expiresAt: new Date(Date.now() + 3600_000),
 }
 
-function buildManager(identity: typeof IDENTITY | null) {
-  const { db } = fakeDb()
-  const { admin, state } = fakeAdmin()
+function buildManager(
+  identity: typeof IDENTITY | null,
+  persistent?: { store: ReturnType<typeof fakeDb>; upstream: ReturnType<typeof fakeAdmin> },
+) {
+  const store = persistent?.store ?? fakeDb()
+  const upstream = persistent?.upstream ?? fakeAdmin()
+  const { db } = store
+  const { admin, state } = upstream
   let published: ProviderConfig[] = []
   const manager = createOperatorAiManager({
     db,
@@ -199,8 +240,18 @@ function buildManager(identity: typeof IDENTITY | null) {
     onRegistryChange: (configs) => {
       published = configs
     },
+    onProviderUnavailable: (slug) => {
+      published = published.filter((config) => config.id !== slug && !config.id.startsWith(`${slug}__`))
+    },
   })
-  return { manager, state, getPublished: () => published }
+  return {
+    manager,
+    state,
+    rows: store.rows,
+    failNext: upstream.failNext,
+    getPublished: () => published,
+    restart: () => buildManager(identity, { store, upstream }),
+  }
 }
 
 describe('operator ai manager helpers', () => {
@@ -221,6 +272,7 @@ describe('operator ai manager helpers', () => {
           enabled: true,
           sortOrder: 1,
           auth: AUTH,
+          ...READY_STATE,
         },
       ],
       new Map([['openai', 'caracal-sys://operator-llm-openai']]),
@@ -234,19 +286,69 @@ describe('operator ai manager helpers', () => {
 
   it('skips a disabled provider and one whose resource did not resolve', () => {
     const disabled = buildStoreProviderConfigs(
-      [{ slug: 'x', label: 'X', baseUrl: 'u', models: ['m'], contextWindow: 0, enabled: false, sortOrder: 1, auth: AUTH }],
+      [{ slug: 'x', label: 'X', baseUrl: 'u', models: ['m'], contextWindow: 0, enabled: false, sortOrder: 1, auth: AUTH, ...READY_STATE }],
       new Map([['x', 'res']]),
       'http://gateway',
       fakeGovernedFetch,
     )
     expect(disabled).toHaveLength(0)
     const unresolved = buildStoreProviderConfigs(
-      [{ slug: 'x', label: 'X', baseUrl: 'u', models: ['m'], contextWindow: 0, enabled: true, sortOrder: 1, auth: AUTH }],
+      [{ slug: 'x', label: 'X', baseUrl: 'u', models: ['m'], contextWindow: 0, enabled: true, sortOrder: 1, auth: AUTH, ...READY_STATE }],
       new Map(),
       'http://gateway',
       fakeGovernedFetch,
     )
     expect(unresolved).toHaveLength(0)
+  })
+
+  it('never publishes a provider whose durable reconciliation is incomplete', () => {
+    const configs = buildStoreProviderConfigs(
+      [
+        {
+          slug: 'pending',
+          label: 'Pending',
+          baseUrl: 'u',
+          models: ['m'],
+          contextWindow: 0,
+          enabled: true,
+          sortOrder: 1,
+          auth: AUTH,
+          reconciliationState: 'error',
+          reconciliationErrorCode: 'reconciliation_failed',
+          credentialRequired: true,
+          reconciledAt: null,
+        },
+      ],
+      new Map([['pending', 'res']]),
+      'http://gateway',
+      fakeGovernedFetch,
+    )
+    expect(configs).toEqual([])
+  })
+
+  it('does not publish a migrated ready row until its live resource has been verified', () => {
+    const configs = buildStoreProviderConfigs(
+      [
+        {
+          slug: 'legacy',
+          label: 'Legacy',
+          baseUrl: 'https://legacy.example/v1',
+          models: ['legacy-model'],
+          contextWindow: 0,
+          enabled: true,
+          sortOrder: 1,
+          auth: AUTH,
+          reconciliationState: 'ready',
+          reconciliationErrorCode: null,
+          credentialRequired: false,
+          reconciledAt: null,
+        },
+      ],
+      new Map([['legacy', 'caracal-sys://operator-llm-legacy']]),
+      'http://gateway',
+      fakeGovernedFetch,
+    )
+    expect(configs).toEqual([])
   })
 
   it('lets a store upstream shadow an env upstream and only seals the override slug', () => {
@@ -262,6 +364,7 @@ describe('operator ai manager helpers', () => {
           enabled: true,
           sortOrder: 1,
           auth: AUTH,
+          ...READY_STATE,
         },
       ],
       { slug: 'openai', apiKey: 'new-key' },
@@ -284,6 +387,7 @@ describe('operator ai manager helpers', () => {
           enabled: true,
           sortOrder: 1,
           auth: AUTH,
+          ...READY_STATE,
         },
       ],
     )
@@ -330,6 +434,226 @@ describe('operator ai manager lifecycle', () => {
     expect(state.policySets[0]?.active_version_id).toBeTruthy()
     // Two models on one provider yield two gateway entries sharing the sealed resource.
     expect(getPublished().map((c) => c.id)).toEqual(['openai__gpt_5_5', 'openai__gpt_5_4'])
+  })
+
+  it('keeps a failed create inert across restart until it is retried with the key', async () => {
+    const first = buildManager(IDENTITY)
+    first.failNext('provider.create:provider://caracal-sys-operator-llm-openai')
+    await expect(
+      first.manager.create({
+        slug: 'openai',
+        label: 'OpenAI',
+        baseUrl: 'https://api/v1',
+        models: ['gpt-5.5'],
+        contextWindow: 0,
+        apiKey: 'sk-create-secret',
+        enabled: true,
+        auth: AUTH,
+      }),
+    ).rejects.toThrow('injected failure')
+
+    expect(first.rows.get('openai')).toMatchObject({
+      reconciliation_state: 'error',
+      reconciliation_error_code: 'reconciliation_failed',
+      credential_required: true,
+    })
+    expect(first.getPublished()).toEqual([])
+    expect(JSON.stringify([...first.rows.values()])).not.toContain('sk-create-secret')
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+    expect(restarted.rows.get('openai')?.reconciliation_state).toBe('error')
+    expect(restarted.state.providers).toEqual([])
+    expect(restarted.getPublished()).toEqual([])
+
+    const view = await restarted.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-create-retry',
+      enabled: true,
+      auth: AUTH,
+    })
+    expect(view.reconciliationState).toBe('ready')
+    expect(view.credentialRequired).toBe(false)
+    expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
+  })
+
+  it('preserves but never grants a key sealed before create reconciliation fails', async () => {
+    const first = buildManager(IDENTITY)
+    first.failNext('resource.create:caracal-sys://operator-llm-openai')
+    await expect(
+      first.manager.create({
+        slug: 'openai',
+        label: 'OpenAI',
+        baseUrl: 'https://api/v1',
+        models: ['gpt-5.5'],
+        contextWindow: 0,
+        apiKey: 'sk-partially-sealed',
+        enabled: true,
+        auth: AUTH,
+      }),
+    ).rejects.toThrow('injected failure')
+
+    expect(first.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: true })
+    expect(first.state.providers).toHaveLength(1)
+    expect(first.state.providers[0].config_json.api_key).toBe('sk-partially-sealed')
+    expect(first.state.resources).toEqual([])
+    expect(first.state.policySets).toEqual([])
+    expect(first.getPublished()).toEqual([])
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+    expect(restarted.state.providers).toHaveLength(1)
+    expect(restarted.state.resources).toEqual([])
+    expect(restarted.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: true })
+    expect(restarted.getPublished()).toEqual([])
+
+    await restarted.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-explicit-retry',
+      enabled: true,
+      auth: AUTH,
+    })
+    expect(restarted.state.providers[0].config_json.api_key).toBe('sk-explicit-retry')
+    expect(restarted.state.resources).toHaveLength(1)
+    expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
+  })
+
+  it('marks migrated metadata with no sealed provider as credential-required on startup', async () => {
+    const restarted = buildManager(IDENTITY)
+    restarted.rows.set('legacy', {
+      slug: 'legacy',
+      label: 'Legacy',
+      base_url: 'https://legacy.example/v1',
+      models: ['legacy-model'],
+      context_window: 0,
+      enabled: true,
+      sort_order: 1,
+      auth_config: AUTH,
+      reconciliation_state: 'ready',
+      reconciliation_error_code: null,
+      credential_required: false,
+      reconciled_at: null,
+    })
+
+    expect((await restarted.manager.list())[0]).toMatchObject({ reconciliationState: 'pending', reconciledAt: null })
+    await restarted.manager.recover()
+
+    expect(restarted.rows.get('legacy')).toMatchObject({
+      reconciliation_state: 'error',
+      reconciliation_error_code: 'reconciliation_failed',
+      credential_required: true,
+    })
+    expect(restarted.getPublished()).toEqual([])
+  })
+
+  it('does not repoint a migrated sealed credential when metadata and the live endpoint diverge', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://old.example/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-old',
+      enabled: true,
+      auth: AUTH,
+    })
+    // Reproduce an update committed by the pre-migration metadata-first implementation. The
+    // registry names the new host while the sealed resource (and its old key) still names the
+    // original host, and the migrated row has no reconciliation proof.
+    const row = first.rows.get('openai')!
+    row.base_url = 'https://new.example/v1'
+    row.reconciled_at = null
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+
+    expect(restarted.rows.get('openai')).toMatchObject({
+      reconciliation_state: 'error',
+      reconciliation_error_code: 'reconciliation_failed',
+      credential_required: true,
+      reconciled_at: null,
+    })
+    expect(restarted.state.resources[0].upstream_url).toBe('https://old.example/v1')
+    expect(restarted.state.providers[0].config_json.api_key).toBe('sk-old')
+    expect(restarted.getPublished()).toEqual([])
+  })
+
+  it('verifies and republishes a migrated row when its sealed provider and endpoint agree', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api.example/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-sealed',
+      enabled: true,
+      auth: AUTH,
+    })
+    first.rows.get('openai')!.reconciled_at = null
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+
+    expect(restarted.rows.get('openai')).toMatchObject({
+      reconciliation_state: 'ready',
+      reconciliation_error_code: null,
+      credential_required: false,
+      reconciled_at: '2026-08-20T00:00:00.000Z',
+    })
+    expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
+  })
+
+  it('keeps an unverified legacy row out of ordinary reconciliations after recovery fails', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'legacy',
+      label: 'Legacy',
+      baseUrl: 'https://legacy.example/v1',
+      models: ['legacy-model'],
+      contextWindow: 0,
+      apiKey: 'sk-legacy',
+      enabled: true,
+      auth: AUTH,
+    })
+    const legacyRow = first.rows.get('legacy')!
+    legacyRow.reconciled_at = null
+    legacyRow.auth_config = { location: 'header', headerName: 'X-API-Key' }
+
+    const restarted = first.restart()
+    restarted.failNext(`provider.patch:${restarted.state.providers[0].id}`)
+    await expect(restarted.manager.recover()).rejects.toThrow('injected failure')
+    expect(restarted.rows.get('legacy')).toMatchObject({
+      reconciliation_state: 'pending',
+      credential_required: false,
+      reconciled_at: null,
+    })
+    expect(restarted.getPublished()).toEqual([])
+
+    await restarted.manager.create({
+      slug: 'other',
+      label: 'Other',
+      baseUrl: 'https://other.example/v1',
+      models: ['other-model'],
+      contextWindow: 0,
+      apiKey: 'sk-other',
+      enabled: true,
+      auth: AUTH,
+    })
+    expect(restarted.rows.get('legacy')?.reconciliation_state).toBe('pending')
+    expect(restarted.state.providers.find((provider) => provider.identifier.endsWith('-legacy'))?.config_json.header_name).toBe(
+      'Authorization',
+    )
+    expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['other'])
   })
 
   it('places the sealed key in a custom header when the upstream wants one (Azure api-key)', async () => {
@@ -456,6 +780,74 @@ describe('operator ai manager lifecycle', () => {
     expect(state.providers[0].config_json.api_key).toBe('sk-2')
   })
 
+  it('fails closed on a partial endpoint move and requires the key again after restart', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-old',
+      enabled: true,
+      auth: AUTH,
+    })
+    const resourceId = first.state.resources[0].id
+    first.failNext(`resource.patch:${resourceId}`)
+
+    await expect(first.manager.update('openai', { baseUrl: 'https://api-2/v1', apiKey: 'sk-new' })).rejects.toThrow('injected failure')
+    expect(first.rows.get('openai')).toMatchObject({
+      base_url: 'https://api-2/v1',
+      reconciliation_state: 'error',
+      credential_required: true,
+    })
+    expect(first.getPublished()).toEqual([])
+    expect(JSON.stringify([...first.rows.values()])).not.toContain('sk-new')
+    expect(first.state.policies[0].versions).toHaveLength(2)
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+    // Recovery preserves the sealed provider but does not point the old resource at the desired
+    // endpoint without receiving the key again.
+    expect(restarted.state.resources[0].upstream_url).toBe('https://api/v1')
+    expect(restarted.rows.get('openai')?.reconciliation_state).toBe('error')
+    await expect(restarted.manager.update('openai', { label: 'Still pending' })).rejects.toBeInstanceOf(OperatorAiKeyRequiredError)
+
+    const view = await restarted.manager.update('openai', { apiKey: 'sk-new-retry' })
+    expect(view.reconciliationState).toBe('ready')
+    expect(restarted.state.resources[0].upstream_url).toBe('https://api-2/v1')
+    expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
+  })
+
+  it('replays a metadata-only reconciliation after restart without retaining a key', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-stays-sealed',
+      enabled: true,
+      auth: AUTH,
+    })
+    first.failNext(`provider.patch:${first.state.providers[0].id}`)
+    await expect(first.manager.update('openai', { auth: { location: 'header', headerName: 'X-API-Key' } })).rejects.toThrow(
+      'injected failure',
+    )
+    expect(first.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: false })
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+    expect(restarted.rows.get('openai')).toMatchObject({
+      reconciliation_state: 'ready',
+      reconciliation_error_code: null,
+      credential_required: false,
+    })
+    expect(restarted.state.providers[0].config_json.header_name).toBe('X-API-Key')
+    expect(restarted.state.providers[0].config_json.api_key).toBe('sk-stays-sealed')
+  })
+
   it('rejects rotate and update for an unknown provider', async () => {
     const { manager } = buildManager(IDENTITY)
     await expect(manager.rotateKey('ghost', 'k')).rejects.toBeInstanceOf(OperatorAiNotFoundError)
@@ -480,6 +872,57 @@ describe('operator ai manager lifecycle', () => {
     expect(getPublished()).toHaveLength(0)
   })
 
+  it('keeps a delete tombstone and completes stale sealed-resource cleanup after restart', async () => {
+    const first = buildManager(IDENTITY)
+    await first.manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-delete',
+      enabled: true,
+      auth: AUTH,
+    })
+    first.failNext(`provider.delete:${first.state.providers[0].id}`)
+    await expect(first.manager.remove('openai')).rejects.toThrow('injected failure')
+    expect(first.rows.get('openai')).toMatchObject({
+      reconciliation_state: 'deleting',
+      reconciliation_error_code: 'reconciliation_failed',
+    })
+    expect(first.getPublished()).toEqual([])
+    // The best-effort fail-closed pass already removed the provider after the injected transient
+    // delete failure; the tombstone remains so a restart can durably finish the metadata side.
+    expect(first.state.providers).toEqual([])
+
+    const restarted = first.restart()
+    await restarted.manager.recover()
+    expect(restarted.rows.has('openai')).toBe(false)
+    expect(restarted.state.providers).toEqual([])
+    expect(restarted.getPublished()).toEqual([])
+  })
+
+  it('cleans a stale sealed provider when legacy partial deletion already removed metadata', async () => {
+    const { manager, rows, state, getPublished } = buildManager(IDENTITY)
+    await manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-delete',
+      enabled: true,
+      auth: AUTH,
+    })
+    // Reproduce the pre-tombstone failure mode from an older process: metadata disappeared while
+    // the sealed provider and its grant survived.
+    rows.delete('openai')
+
+    expect(await manager.remove('openai')).toBe(false)
+    expect(state.providers).toEqual([])
+    expect(getPublished()).toEqual([])
+  })
+
   it('lists configured providers without keys', async () => {
     const { manager } = buildManager(IDENTITY)
     await manager.create({
@@ -496,5 +939,6 @@ describe('operator ai manager lifecycle', () => {
     expect(list).toHaveLength(1)
     expect(list[0]).not.toHaveProperty('apiKey')
     expect(list[0].slug).toBe('openai')
+    expect(list[0]).toMatchObject({ reconciliationState: 'ready', reconciliationErrorCode: null, credentialRequired: false })
   })
 })

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -10,12 +10,14 @@ import {
   createOperatorAiManager,
   buildStoreProviderConfigs,
   mergeDesiredUpstreams,
+  planStoreUpstreams,
   providerConfigId,
   OperatorAiUnavailableError,
   OperatorAiNotFoundError,
   OperatorAiKeyRequiredError,
   OperatorAiConflictError,
 } from '../../../../apps/api/src/operator-ai-manager.js'
+import type { OperatorAiProviderRecord } from '../../../../apps/api/src/operator-ai-store.js'
 import type { ProviderConfig } from '../../../../apps/api/src/operator-gateway.js'
 import type { OperatorControlIdentity } from '../../../../apps/api/src/config.js'
 
@@ -391,6 +393,82 @@ describe('operator ai manager helpers', () => {
       ],
     )
     expect(merged[0].apiKey).toBeUndefined()
+  })
+})
+
+describe('store upstream plan', () => {
+  function record(slug: string, overrides: Partial<OperatorAiProviderRecord>): OperatorAiProviderRecord {
+    return {
+      slug,
+      label: slug,
+      baseUrl: `https://${slug}.example/v1`,
+      models: ['m'],
+      contextWindow: 0,
+      enabled: true,
+      sortOrder: 1,
+      auth: AUTH,
+      ...READY_STATE,
+      ...overrides,
+    }
+  }
+
+  it('routes only rows proven to match their sealed resource and preserves the rest', () => {
+    const plan = planStoreUpstreams(
+      [],
+      [
+        record('proven', {}),
+        record('migrated', { reconciledAt: null }),
+        record('waiting', { reconciliationState: 'error', reconciledAt: null, credentialRequired: true }),
+        record('replayable', { reconciliationState: 'error', reconciledAt: null, credentialRequired: false }),
+        record('tombstone', { reconciliationState: 'deleting', reconciledAt: null }),
+      ],
+    )
+
+    expect(plan.upstreams.map((upstream) => upstream.id)).toEqual(['proven'])
+    // A tombstone is deliberately absent from both sets so its sealed provider is pruned.
+    expect(plan.preservedSlugs).toEqual(['migrated', 'waiting', 'replayable'])
+  })
+
+  it('replays the rows a restart can finish without a key', () => {
+    const plan = planStoreUpstreams(
+      [],
+      [
+        record('replayable', { reconciliationState: 'pending', reconciledAt: null, credentialRequired: false }),
+        record('waiting', { reconciliationState: 'pending', reconciledAt: null, credentialRequired: true }),
+      ],
+      { recover: true },
+    )
+
+    expect(plan.upstreams.map((upstream) => upstream.id)).toEqual(['replayable'])
+    expect(plan.preservedSlugs).toEqual(['waiting'])
+  })
+
+  it('admits the slug whose lifecycle write is driving the pass', () => {
+    const plan = planStoreUpstreams(
+      [],
+      [record('openai', { reconciliationState: 'pending', reconciledAt: null, credentialRequired: true })],
+      {
+        targetSlug: 'openai',
+        keyOverride: { slug: 'openai', apiKey: 'sk-inflight' },
+      },
+    )
+
+    expect(plan.upstreams).toEqual([{ id: 'openai', baseUrl: 'https://openai.example/v1', apiKey: 'sk-inflight', auth: AUTH }])
+    expect(plan.preservedSlugs).toEqual([])
+  })
+
+  it('lets a preserved store row shadow the env upstream that shares its slug', () => {
+    const plan = planStoreUpstreams(
+      [
+        { id: 'openai', baseUrl: 'https://env.example/v1', apiKey: 'sk-env' },
+        { id: 'other', baseUrl: 'https://other.example/v1', apiKey: 'sk-other' },
+      ],
+      [record('openai', { reconciliationState: 'error', reconciledAt: null, credentialRequired: true })],
+    )
+
+    // Sealing the env key here would overwrite the very provider this pass must leave untouched.
+    expect(plan.upstreams.map((upstream) => upstream.id)).toEqual(['other'])
+    expect(plan.preservedSlugs).toEqual(['openai'])
   })
 })
 
@@ -995,6 +1073,26 @@ describe('operator ai manager lifecycle', () => {
     expect(restarted.rows.has('openai')).toBe(false)
     expect(restarted.state.providers).toEqual([])
     expect(restarted.getPublished()).toEqual([])
+  })
+
+  it('does nothing on a rotation tick once every row is reconciled', async () => {
+    const { manager, state, restart } = buildManager(IDENTITY)
+    await manager.create({
+      slug: 'openai',
+      label: 'OpenAI',
+      baseUrl: 'https://api/v1',
+      models: ['gpt-5.5'],
+      contextWindow: 0,
+      apiKey: 'sk-steady',
+      enabled: true,
+      auth: AUTH,
+    })
+
+    // recover() runs on every rotation tick, so a converged store must not re-seal anything.
+    const steady = restart()
+    state.calls.length = 0
+    await steady.manager.recover()
+    expect(state.calls).toEqual([])
   })
 
   it('refuses to edit or rotate a tombstone back into a live sealed endpoint', async () => {

--- a/tests/typescript/unit/api/operator-ai-manager.test.ts
+++ b/tests/typescript/unit/api/operator-ai-manager.test.ts
@@ -224,6 +224,7 @@ const IDENTITY: OperatorControlIdentity = {
 function buildManager(
   identity: typeof IDENTITY | null,
   persistent?: { store: ReturnType<typeof fakeDb>; upstream: ReturnType<typeof fakeAdmin> },
+  envUpstreams: { id: string; baseUrl: string; apiKey?: string }[] = [],
 ) {
   const store = persistent?.store ?? fakeDb()
   const upstream = persistent?.upstream ?? fakeAdmin()
@@ -234,7 +235,7 @@ function buildManager(
     db,
     admin,
     resolveIdentity: () => identity,
-    envUpstreams: [],
+    envUpstreams,
     gatewayUrl: 'http://gateway',
     governedFetch: fakeGovernedFetch,
     onRegistryChange: (configs) => {
@@ -250,7 +251,7 @@ function buildManager(
     rows: store.rows,
     failNext: upstream.failNext,
     getPublished: () => published,
-    restart: () => buildManager(identity, { store, upstream }),
+    restart: () => buildManager(identity, { store, upstream }, envUpstreams),
   }
 }
 
@@ -524,6 +525,39 @@ describe('operator ai manager lifecycle', () => {
     expect(restarted.state.providers[0].config_json.api_key).toBe('sk-explicit-retry')
     expect(restarted.state.resources).toHaveLength(1)
     expect(restarted.getPublished().map((provider) => provider.id)).toEqual(['openai'])
+  })
+
+  it('keeps a failed store row shadowing an env upstream with the same slug', async () => {
+    const first = buildManager(IDENTITY, undefined, [{ id: 'openai', baseUrl: 'https://env.example/v1', apiKey: 'sk-env' }])
+    first.failNext('resource.create:caracal-sys://operator-llm-openai')
+    await expect(
+      first.manager.create({
+        slug: 'openai',
+        label: 'Store OpenAI',
+        baseUrl: 'https://store.example/v1',
+        models: ['gpt-5.5'],
+        contextWindow: 0,
+        apiKey: 'sk-store',
+        enabled: true,
+        auth: AUTH,
+      }),
+    ).rejects.toThrow('injected failure')
+
+    await first.manager.create({
+      slug: 'other',
+      label: 'Other',
+      baseUrl: 'https://other.example/v1',
+      models: ['other-model'],
+      contextWindow: 0,
+      apiKey: 'sk-other',
+      enabled: true,
+      auth: AUTH,
+    })
+
+    const failedProvider = first.state.providers.find((provider) => provider.identifier.endsWith('-openai'))
+    expect(failedProvider?.config_json.api_key).toBe('sk-store')
+    expect(first.rows.get('openai')).toMatchObject({ reconciliation_state: 'error', credential_required: true })
+    expect(first.getPublished().map((provider) => provider.id)).toEqual(['other'])
   })
 
   it('marks migrated metadata with no sealed provider as credential-required on startup', async () => {

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -12,7 +12,11 @@ import { operatorRoutes } from '../../../../../apps/api/src/routes/operator.js'
 import { CAPABILITIES } from '../../../../../apps/api/src/operator-capabilities.js'
 import { isControlExecutable } from '../../../../../apps/api/src/operator-control-map.js'
 import { buildAutopilotPolicy } from '../../../../../apps/api/src/operator-autopilot.js'
-import type { OperatorAiManager } from '../../../../../apps/api/src/operator-ai-manager.js'
+import {
+  OperatorAiConflictError,
+  OperatorAiKeyRequiredError,
+  type OperatorAiManager,
+} from '../../../../../apps/api/src/operator-ai-manager.js'
 import type { OperatorAiHealthStore } from '../../../../../apps/api/src/operator-ai-health.js'
 import type { OperatorControlIdentity } from '../../../../../apps/api/src/config.js'
 import type { OperatorRunLimiter } from '../../../../../apps/api/src/operator-run-limiter.js'
@@ -111,6 +115,62 @@ function sysIdentity(zoneId: string): OperatorControlIdentity {
     expiresAt: new Date(Date.now() + 3600_000),
   }
 }
+
+function rejectingAiManager(error: Error): OperatorAiManager {
+  return {
+    available: () => true,
+    list: async () => [],
+    create: async () => {
+      throw error
+    },
+    update: async () => {
+      throw error
+    },
+    rotateKey: async () => {
+      throw error
+    },
+    remove: async () => {
+      throw error
+    },
+    recover: async () => {},
+  }
+}
+
+describe('operator AI provider lifecycle errors', () => {
+  it('returns a conflict instead of replacing an existing provider through POST', async () => {
+    const { app } = buildApp(true, { aiManager: rejectingAiManager(new OperatorAiConflictError('openai')) })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/operator/ai/providers',
+      payload: {
+        slug: 'openai',
+        label: 'OpenAI',
+        base_url: 'https://api.example/v1',
+        models: ['gpt-5.5'],
+        context_window: 0,
+        api_key: 'sk-test',
+        enabled: true,
+      },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toEqual({ error: 'provider_already_exists' })
+    await app.close()
+  })
+
+  it('returns the key-required code used by the edit retry flow', async () => {
+    const { app } = buildApp(true, { aiManager: rejectingAiManager(new OperatorAiKeyRequiredError('openai')) })
+    await app.ready()
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/v1/operator/ai/providers/openai',
+      payload: { label: 'Retry' },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json()).toEqual({ error: 'api_key_required_for_base_url_change' })
+    await app.close()
+  })
+})
 
 // The internal control identity and endpoints that make governed execution available for
 // zone z1: the identity is bound to z1, so the control token executes in z1.

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -167,7 +167,7 @@ describe('operator AI provider lifecycle errors', () => {
       payload: { label: 'Retry' },
     })
     expect(res.statusCode).toBe(400)
-    expect(res.json()).toEqual({ error: 'api_key_required_for_base_url_change' })
+    expect(res.json()).toEqual({ error: 'api_key_required' })
     await app.close()
   })
 })

--- a/tests/typescript/unit/api/system-zone.test.ts
+++ b/tests/typescript/unit/api/system-zone.test.ts
@@ -494,6 +494,22 @@ describe('provisionSystemZone with governed upstreams', () => {
     expect(result.governedResources).toEqual([])
   })
 
+  it('retains a pending provider credential while revoking its grant', async () => {
+    const { admin, state } = fakeAdmin({ zones: [{ id: 'zone-sys', name: SYSTEM_ZONE_NAME, slug: SYSTEM_ZONE_SLUG }] })
+    await provisionSystemZone(admin, 'caracal-control', fakeFindZoneBySlug(state), roles, [upstream])
+    state.calls.length = 0
+
+    const result = await provisionSystemZone(admin, 'caracal-control', fakeFindZoneBySlug(state), roles, [], ['openai'])
+
+    // A credential-dependent pending/error row cannot be replayed without persisting its key.
+    // Preserve the sealed provider for an explicit retry, but remove runtime authority to it.
+    expect(state.providers).toHaveLength(1)
+    expect(state.calls).not.toContain('providers.delete')
+    expect(result.governedResources).toEqual([])
+    expect(state.policies[0].versions).toHaveLength(2)
+    expect(state.calls).toContain('policySets.activate')
+  })
+
   it('re-adds a previously pruned upstream cleanly: a fresh provider re-bound to the reused resource', async () => {
     const { admin, state } = fakeAdmin({ zones: [{ id: 'zone-sys', name: SYSTEM_ZONE_NAME, slug: SYSTEM_ZONE_SLUG }] })
     await provisionSystemZone(admin, 'caracal-control', fakeFindZoneBySlug(state), roles, [upstream])


### PR DESCRIPTION
## Summary

- persist provider lifecycle reconciliation state, credential requirements, and a reconciliation proof timestamp
- fail closed during create, update, key rotation, and delete; preserve sealed credentials without granting or routing failed providers
- recover metadata-only work and delete tombstones after restart while requiring explicit key resubmission for credential-dependent failures
- quarantine pre-migration rows when live endpoint metadata disagrees, preventing an old sealed key from being silently repointed to a new host
- reject duplicate creates atomically and expose lifecycle recovery in the provider API and console
- close pooled test HTTP connections deterministically so the governed boot integration shuts down reliably on Node 24

## Safety properties

- plaintext provider keys are never written to registry metadata, reconciliation state, or logs
- pending/error providers are removed from the runtime registry and their grants are revoked
- legacy rows and unrecognized states fail closed until their sealed provider/resource pairing is verified
- delete remains retryable even when metadata was already removed by an older process

## Validation

- `pnpm run build:typescript`
- `pnpm run typecheck`
- `pnpm run style`
- `pnpm run lint` (0 errors; 232 pre-existing warnings)
- complete API unit suite: 74 files, 1,386 tests
- broader TypeScript validation: 1,453 API tests and 394 web tests
- `PYTHON=.venv/bin/python pnpm run test:python` (504 tests)
- production web build
- PostgreSQL 18 migration apply, idempotency, concurrent-runner, and schema verification
- live PostgreSQL schema integration suite: 7 tests
- manager lifecycle plus PostgreSQL schema suite: 40 tests repeated successfully 10 consecutive times (400 checks)
- complete PostgreSQL integration suite: 14 tests repeated successfully 10 consecutive times (140 checks)
- separate complete integration run inside `node:24-bookworm-slim`, matching CI
- final GitHub checks green, including PostgreSQL 18, TypeScript, stack E2E, CodeQL, and Semgrep

Closes #412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider reconciliation status, error details, credential requirements, and last-reconciled timestamps.
  * Added recovery and safer lifecycle handling for pending, failed, unavailable, and deleting providers.
  * Preserved pending providers during system provisioning while revoking invalid access.

* **Bug Fixes**
  * Prevented duplicate provider creation and environment settings from unintentionally overriding stored providers.
  * Added clearer guidance when credentials are required and disabled unsafe edits during deletion.

* **API**
  * Provider conflicts now return a clear `409 provider_already_exists` response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->